### PR TITLE
Hitable as enum, initial work for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ gui = ["pixels", "winit", "winit_input_helper"]
 
 [dependencies]
 image = "0.23.5"
-nalgebra = "0.21.1"
+nalgebra = {version = "0.21.1", features = ["serde-serialize"] }
 rayon = "1.3.1"
 rand = "0.7.3"
 chrono = "0.4.11"
 humantime = "2.0.1"
 indicatif = { version = "0.15.0", features = ["rayon"] }
 clap = "3.0.0-beta.1"
-serde = { version = "1.0", features = ["derive"] } 
+serde = { version = "1.0", features = ["derive", "rc"] } 
 toml = "0.5.6"
 
 pixels = {version = "0.0.4", optional=true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ chrono = "0.4.11"
 humantime = "2.0.1"
 indicatif = { version = "0.15.0", features = ["rayon"] }
 clap = "3.0.0-beta.1"
+serde = { version = "1.0", features = ["derive"] } 
+toml = "0.5.6"
 
 pixels = {version = "0.0.4", optional=true }
 winit = {version = "0.22.2", optional=true }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,6 @@
 use crate::{Float, Ray, Vec3, PI};
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
 fn random_in_unit_disk(rng: &mut ThreadRng) -> Vec3 {
     let mut position: Vec3;
@@ -12,6 +13,7 @@ fn random_in_unit_disk(rng: &mut ThreadRng) -> Vec3 {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct Camera {
     pub lower_left_corner: Vec3,
     pub horizontal: Vec3,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,11 @@
+use serde::{Deserialize, Serialize};
+
 use crate::{Float, ThreadRng, Vec3};
 use image::Rgb;
 use rand::prelude::*;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Color {
     pub r: Float,
     pub g: Float,

--- a/src/colorize.rs
+++ b/src/colorize.rs
@@ -5,7 +5,7 @@ use rand::prelude::ThreadRng;
 pub fn colorize(
     ray: &Ray,
     background_color: Color,
-    world: &dyn Hitable,
+    world: &Hitable,
     depth: u32,
     max_depth: u32,
     rng: ThreadRng,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -18,8 +18,6 @@ pub fn draw(
 
     let rng = rand::thread_rng();
     let scene = scenes::cornell_with_sphere::load(width, height, rng);
-    let world = scene.world;
-    let camera: Camera = scene.camera;
     let background_color: Color = scene.background;
 
     // Progress bar
@@ -43,8 +41,8 @@ pub fn draw(
             for _sample in 0..samples {
                 u = (x as Float + rng.gen::<Float>()) / width as Float;
                 v = (y as Float + rng.gen::<Float>()) / height as Float;
-                ray = camera.get_ray(u, v, rng);
-                color += colorize(&ray, background_color, &world, 0, max_depth, rng);
+                ray = scene.camera.get_ray(u, v, rng);
+                color += colorize(&ray, background_color, &scene.world, 0, max_depth, rng);
             }
             color /= samples as Float;
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,10 +1,5 @@
 use crate::{
-    camera::Camera,
-    color::Color,
-    colorize::colorize,
-    hitable::{BVHNode},
-    ray::Ray,
-    scenes, Float,
+    camera::Camera, color::Color, colorize::colorize, hitable::BVHNode, ray::Ray, scenes, Float,
 };
 use image::{ImageBuffer, ImageResult, RgbImage};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -23,7 +18,7 @@ pub fn draw(
 
     let rng = rand::thread_rng();
     let scene = scenes::cornell_with_sphere::load(width, height, rng);
-    let world: BVHNode = scene.world;
+    let world = scene.world;
     let camera: Camera = scene.camera;
     let background_color: Color = scene.background;
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,4 @@
-use crate::{
-    camera::Camera, color::Color, colorize::colorize, hitable::BVHNode, ray::Ray, scenes, Float,
-};
+use crate::{color::Color, colorize::colorize, ray::Ray, scenes, Float};
 use image::{ImageBuffer, ImageResult, RgbImage};
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::prelude::*;

--- a/src/draw_gui.rs
+++ b/src/draw_gui.rs
@@ -126,7 +126,7 @@ impl World {
         let width = self.width as usize;
         let height = self.height as usize;
         let camera = &self.scene.camera;
-        let world: &dyn Hitable = &self.scene.world;
+        let world = &self.scene.world;
 
         // Update internal float-based pixel buffer with new samples
         self.float_buffer

--- a/src/draw_gui.rs
+++ b/src/draw_gui.rs
@@ -1,7 +1,6 @@
 use crate::{
     color::Color,
     colorize::colorize,
-    hitable::Hitable,
     scenes::{self, Scene},
     Float,
 };

--- a/src/hitable.rs
+++ b/src/hitable.rs
@@ -45,7 +45,7 @@ impl<'a> HitRecord<'a> {
 //         distance_min: Float,
 //         distance_max: Float,
 //         rng: ThreadRng,
-//     ) -> Option<HitRecord>;
+//     ) -> Option<&HitRecord>;
 //     fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB>;
 // }
 
@@ -123,7 +123,7 @@ impl HitableList {
         let mut hit_record: Option<HitRecord> = None;
         let mut closest = distance_max;
         for &hitable in self.0.iter() {
-            if let Some(record) = hitable.hit(&ray, distance_min, closest, rng) {
+            if let Some(record) = hitable.hit(ray, distance_min, closest, rng) {
                 closest = record.distance;
                 hit_record = Some(record);
             }
@@ -168,14 +168,14 @@ impl HitableList {
     pub fn new() -> HitableList {
         HitableList(Vec::new())
     }
-    // TODO: figure out this helper
-    //     pub fn add(&self, object: dyn Hitable) {
-    //         self.hitables.push(Box::new(object));
-    //     }
 
-    pub fn into_bvh(self, time_0: Float, time_1: Float, rng: ThreadRng) -> BVHNode {
+    pub fn add(&self, object: Hitable) {
+        self.0.push(object);
+    }
+
+    pub fn into_bvh(self, time_0: Float, time_1: Float, rng: ThreadRng) -> Hitable {
         let bvh_node = BVHNode::from_list(self.0, time_0, time_1, rng);
-        bvh_node
+        Hitable::BVHNode(bvh_node)
     }
 }
 

--- a/src/hitable.rs
+++ b/src/hitable.rs
@@ -38,18 +38,6 @@ impl<'a> HitRecord<'a> {
     }
 }
 
-// pub trait Hitable: Sync + Send {
-//     /// The main function for checking whether an object is hit by a ray. If an object is hit, returns Some(HitRecord)
-//     fn hit(
-//         &self,
-//         ray: &Ray,
-//         distance_min: Float,
-//         distance_max: Float,
-//         rng: ThreadRng,
-//     ) -> Option<&HitRecord>;
-//     fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB>;
-// }
-
 #[derive(Deserialize, Serialize)]
 pub enum Hitable {
     Boxy(Boxy),

--- a/src/hitable.rs
+++ b/src/hitable.rs
@@ -6,6 +6,7 @@ use crate::{
     Float, Ray, Vec3,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, sync::Arc};
 
 pub struct HitRecord<'a> {
@@ -49,6 +50,7 @@ impl<'a> HitRecord<'a> {
 //     fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB>;
 // }
 
+#[derive(Deserialize, Serialize)]
 pub enum Hitable {
     Boxy(Boxy),
     ConstantMedium(ConstantMedium),
@@ -104,6 +106,7 @@ impl Hitable {
 }
 
 /// Helper struct for storing multiple `Hitable` objects. This list has a `Hitable` implementation too, returning the closest possible hit
+#[derive(Deserialize, Serialize)]
 pub struct HitableList(pub Vec<Arc<Hitable>>);
 
 impl From<Vec<Arc<Hitable>>> for HitableList {
@@ -179,7 +182,7 @@ impl HitableList {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 pub struct AABB {
     pub min: Vec3,
     pub max: Vec3,
@@ -225,6 +228,7 @@ impl AABB {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct BVHNode {
     left: Arc<Hitable>,
     right: Arc<Hitable>,

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -1,5 +1,7 @@
-use crate::{color::Color, hitable::HitRecord, Float, Ray, ThreadRng, Vec3, PI};
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{color::Color, hitable::HitRecord, Float, Ray, ThreadRng, Vec3, PI};
 pub mod dielectric;
 pub mod diffuse_light;
 pub mod isotropic;
@@ -12,7 +14,7 @@ pub use isotropic::*;
 pub use lambertian::*;
 pub use metal::*;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub enum Material {
     Dielectric(Dielectric),
     Lambertian(Lambertian),

--- a/src/materials/dielectric.rs
+++ b/src/materials/dielectric.rs
@@ -1,8 +1,9 @@
 use super::{reflect, refract, schlick, Material};
 use crate::{color::Color, hitable::HitRecord, ray::Ray, Float, Vec3};
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Dielectric {
     refractive_index: Float,
 }

--- a/src/materials/diffuse_light.rs
+++ b/src/materials/diffuse_light.rs
@@ -1,7 +1,9 @@
 use super::Material;
 use crate::{color::Color, hitable::HitRecord, ray::Ray, textures::Texture, Float, Vec3};
 use rand::prelude::ThreadRng;
-#[derive(Copy, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct DiffuseLight {
     emit: Texture,
 }

--- a/src/materials/isotropic.rs
+++ b/src/materials/isotropic.rs
@@ -1,7 +1,9 @@
 use super::{random_in_unit_sphere, Material};
 use crate::{color::Color, hitable::HitRecord, ray::Ray, textures::Texture};
 use rand::prelude::ThreadRng;
-#[derive(Copy, Clone)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Isotropic {
     albedo: Texture,
 }

--- a/src/materials/lambertian.rs
+++ b/src/materials/lambertian.rs
@@ -1,8 +1,9 @@
 use super::{random_unit_vector, Material};
 use crate::{color::Color, hitable::HitRecord, ray::Ray, textures::Texture, Vec3};
 use rand::prelude::ThreadRng;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Lambertian {
     albedo: Texture,
 }

--- a/src/materials/metal.rs
+++ b/src/materials/metal.rs
@@ -1,8 +1,9 @@
 use super::{random_in_unit_sphere, reflect, Material};
 use crate::{color::Color, hitable::HitRecord, ray::Ray, textures::Texture, Float, Vec3};
 use rand::prelude::ThreadRng;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Metal {
     albedo: Texture,
     fuzz: Float,

--- a/src/objects/boxy.rs
+++ b/src/objects/boxy.rs
@@ -18,25 +18,25 @@ pub struct Boxy {
 
 impl Boxy {
     pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Hitable {
-        let mut sides: Vec<Hitable> = Vec::new();
-        sides.push(XYRect::new(
+        let mut sides = HitableList::new();
+        sides.add(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_1.z, material,
         ));
-        sides.push(XYRect::new(
+        sides.add(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_0.z, material,
         ));
 
-        sides.push(XZRect::new(
+        sides.add(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_1.y, material,
         ));
-        sides.push(XZRect::new(
+        sides.add(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_0.y, material,
         ));
 
-        sides.push(YZRect::new(
+        sides.add(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_1.x, material,
         ));
-        sides.push(YZRect::new(
+        sides.add(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_0.x, material,
         ));
 

--- a/src/objects/boxy.rs
+++ b/src/objects/boxy.rs
@@ -17,40 +17,38 @@ pub struct Boxy {
 }
 
 impl Boxy {
-    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Boxy {
-        let mut sides = HitableList::new();
-        sides.hitables.push(Arc::new(XYRect::new(
+    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Hitable {
+        let mut sides: Vec<Hitable> = Vec::new();
+        sides.push(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_1.z, material,
-        )));
-        sides.hitables.push(Arc::new(XYRect::new(
+        ));
+        sides.push(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_0.z, material,
-        )));
+        ));
 
-        sides.hitables.push(Arc::new(XZRect::new(
+        sides.push(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_1.y, material,
-        )));
-        sides.hitables.push(Arc::new(XZRect::new(
+        ));
+        sides.push(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_0.y, material,
-        )));
+        ));
 
-        sides.hitables.push(Arc::new(YZRect::new(
+        sides.push(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_1.x, material,
-        )));
-        sides.hitables.push(Arc::new(YZRect::new(
+        ));
+        sides.push(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_0.x, material,
-        )));
+        ));
 
-        Boxy {
+        Hitable::Boxy(Boxy {
             corner_0,
             corner_1,
-            sides,
+            sides: HitableList::from(sides),
             material,
-        }
+        })
     }
-}
 
-impl Hitable for Boxy {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -59,7 +57,8 @@ impl Hitable for Boxy {
     ) -> Option<HitRecord> {
         self.sides.hit(ray, distance_min, distance_max, rng)
     }
-    fn bounding_box(&self, _t0: crate::Float, _t1: crate::Float) -> Option<AABB> {
+
+    pub fn bounding_box(&self, _t0: crate::Float, _t1: crate::Float) -> Option<AABB> {
         Some(AABB::new(self.corner_0, self.corner_1))
     }
 }

--- a/src/objects/boxy.rs
+++ b/src/objects/boxy.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 pub struct Boxy {
     corner_0: Vec3,
     corner_1: Vec3,
-    sides: HitableList,
+    sides: Arc<HitableList>,
     material: Material,
 }
 
@@ -43,7 +43,7 @@ impl Boxy {
         Hitable::Boxy(Boxy {
             corner_0,
             corner_1,
-            sides: HitableList::from(sides),
+            sides: Arc::new(HitableList::from(sides)),
             material,
         })
     }

--- a/src/objects/boxy.rs
+++ b/src/objects/boxy.rs
@@ -6,9 +6,11 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 // Avoid keyword clash
+#[derive(Deserialize, Serialize)]
 pub struct Boxy {
     corner_0: Vec3,
     corner_1: Vec3,

--- a/src/objects/constant_medium.rs
+++ b/src/objects/constant_medium.rs
@@ -9,23 +9,21 @@ use rand::prelude::*;
 use std::sync::Arc;
 
 pub struct ConstantMedium {
-    boundary: Arc<dyn Hitable>,
+    boundary: Arc<Hitable>,
     phase_function: Material,
     neg_inv_density: Float,
 }
 
 impl ConstantMedium {
-    pub fn new(boundary: Arc<dyn Hitable>, density: Float, texture: Texture) -> Self {
-        ConstantMedium {
+    pub fn new(boundary: Arc<Hitable>, density: Float, texture: Texture) -> Hitable {
+        Hitable::ConstantMedium(ConstantMedium {
             boundary,
             phase_function: Isotropic::new(texture),
             neg_inv_density: -1.0 / density,
-        }
+        })
     }
-}
 
-impl Hitable for ConstantMedium {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -95,7 +93,8 @@ impl Hitable for ConstantMedium {
             front_face,
         })
     }
-    fn bounding_box(&self, t0: crate::Float, t1: crate::Float) -> Option<crate::hitable::AABB> {
+
+    pub fn bounding_box(&self, t0: crate::Float, t1: crate::Float) -> Option<crate::hitable::AABB> {
         self.boundary.bounding_box(t0, t1)
     }
 }

--- a/src/objects/constant_medium.rs
+++ b/src/objects/constant_medium.rs
@@ -29,7 +29,7 @@ impl ConstantMedium {
         distance_min: Float,
         distance_max: Float,
         mut rng: ThreadRng,
-    ) -> Option<crate::hitable::HitRecord> {
+    ) -> Option<HitRecord> {
         let mut rec1: HitRecord;
         let mut rec2: HitRecord;
 

--- a/src/objects/constant_medium.rs
+++ b/src/objects/constant_medium.rs
@@ -6,8 +6,10 @@ use crate::{
     Float, Vec3, CONSTANT_MEDIUM_EPSILON,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+#[derive(Deserialize, Serialize)]
 pub struct ConstantMedium {
     boundary: Arc<Hitable>,
     phase_function: Material,

--- a/src/objects/moving_sphere.rs
+++ b/src/objects/moving_sphere.rs
@@ -5,7 +5,9 @@ use crate::{
     Float, Ray, Vec3, PI,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
+#[derive(Deserialize, Serialize)]
 pub struct MovingSphere {
     center_0: Vec3,
     center_1: Vec3,

--- a/src/objects/moving_sphere.rs
+++ b/src/objects/moving_sphere.rs
@@ -23,15 +23,15 @@ impl MovingSphere {
         time_1: Float,
         radius: Float,
         material: Material,
-    ) -> Self {
-        MovingSphere {
+    ) -> Hitable {
+        Hitable::MovingSphere(MovingSphere {
             center_0,
             center_1,
             time_0,
             time_1,
             radius,
             material,
-        }
+        })
     }
     pub fn center(&self, time: Float) -> Vec3 {
         return self.center_0
@@ -48,10 +48,8 @@ impl MovingSphere {
         let v: Float = (theta + PI / 2.0) / PI;
         (u, v)
     }
-}
 
-impl Hitable for MovingSphere {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -105,8 +103,7 @@ impl Hitable for MovingSphere {
         None
     }
 
-    // TODO: might need to return Option<T> ?
-    fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB> {
+    pub fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB> {
         let box0: AABB = AABB::new(
             self.center(t0) - Vec3::new(self.radius, self.radius, self.radius),
             self.center(t0) + Vec3::new(self.radius, self.radius, self.radius),

--- a/src/objects/rect.rs
+++ b/src/objects/rect.rs
@@ -5,9 +5,11 @@ use crate::{
     Float, Vec3, RECT_EPSILON,
 };
 use rand::prelude::ThreadRng;
+use serde::{Deserialize, Serialize};
 
 // XY
 
+#[derive(Deserialize, Serialize)]
 pub struct XYRect {
     x0: Float,
     x1: Float,
@@ -84,6 +86,7 @@ impl XYRect {
 
 // XZ
 
+#[derive(Deserialize, Serialize)]
 pub struct XZRect {
     x0: Float,
     x1: Float,
@@ -160,6 +163,7 @@ impl XZRect {
 
 // YZ
 
+#[derive(Deserialize, Serialize)]
 pub struct YZRect {
     y0: Float,
     y1: Float,

--- a/src/objects/rect.rs
+++ b/src/objects/rect.rs
@@ -18,20 +18,25 @@ pub struct XYRect {
 }
 
 impl XYRect {
-    pub fn new(x0: Float, x1: Float, y0: Float, y1: Float, k: Float, material: Material) -> XYRect {
-        XYRect {
+    pub fn new(
+        x0: Float,
+        x1: Float,
+        y0: Float,
+        y1: Float,
+        k: Float,
+        material: Material,
+    ) -> Hitable {
+        Hitable::XYRect(XYRect {
             x0,
             x1,
             y0,
             y1,
             k,
             material: material,
-        }
+        })
     }
-}
 
-impl Hitable for XYRect {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -63,7 +68,11 @@ impl Hitable for XYRect {
         record.set_face_normal(ray, outward_normal);
         return Some(record);
     }
-    fn bounding_box(&self, _t0: crate::Float, _t1: crate::Float) -> Option<crate::hitable::AABB> {
+    pub fn bounding_box(
+        &self,
+        _t0: crate::Float,
+        _t1: crate::Float,
+    ) -> Option<crate::hitable::AABB> {
         // The bounding box must have non-zero width in each dimension, so pad the Z dimension a small amount.
         let output_box = AABB::new(
             Vec3::new(self.x0, self.y0, self.k - RECT_EPSILON),
@@ -85,20 +94,25 @@ pub struct XZRect {
 }
 
 impl XZRect {
-    pub fn new(x0: Float, x1: Float, z0: Float, z1: Float, k: Float, material: Material) -> XZRect {
-        XZRect {
+    pub fn new(
+        x0: Float,
+        x1: Float,
+        z0: Float,
+        z1: Float,
+        k: Float,
+        material: Material,
+    ) -> Hitable {
+        Hitable::XZRect(XZRect {
             x0,
             x1,
             z0,
             z1,
             k,
             material: material,
-        }
+        })
     }
-}
 
-impl Hitable for XZRect {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -130,7 +144,11 @@ impl Hitable for XZRect {
         record.set_face_normal(ray, outward_normal);
         return Some(record);
     }
-    fn bounding_box(&self, _t0: crate::Float, _t1: crate::Float) -> Option<crate::hitable::AABB> {
+    pub fn bounding_box(
+        &self,
+        _t0: crate::Float,
+        _t1: crate::Float,
+    ) -> Option<crate::hitable::AABB> {
         // The bounding box must have non-zero width in each dimension, so pad the Z dimension a small amount.
         let output_box = AABB::new(
             Vec3::new(self.x0, self.k - RECT_EPSILON, self.z0),
@@ -152,20 +170,25 @@ pub struct YZRect {
 }
 
 impl YZRect {
-    pub fn new(y0: Float, y1: Float, z0: Float, z1: Float, k: Float, material: Material) -> YZRect {
-        YZRect {
+    pub fn new(
+        y0: Float,
+        y1: Float,
+        z0: Float,
+        z1: Float,
+        k: Float,
+        material: Material,
+    ) -> Hitable {
+        Hitable::YZRect(YZRect {
             y0,
             y1,
             z0,
             z1,
             k,
             material: material,
-        }
+        })
     }
-}
 
-impl Hitable for YZRect {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -197,7 +220,11 @@ impl Hitable for YZRect {
         record.set_face_normal(ray, outward_normal);
         return Some(record);
     }
-    fn bounding_box(&self, _t0: crate::Float, _t1: crate::Float) -> Option<crate::hitable::AABB> {
+    pub fn bounding_box(
+        &self,
+        _t0: crate::Float,
+        _t1: crate::Float,
+    ) -> Option<crate::hitable::AABB> {
         // The bounding box must have non-zero width in each dimension, so pad the Z dimension a small amount.
         let output_box = AABB::new(
             Vec3::new(self.k - RECT_EPSILON, self.y0, self.z0),

--- a/src/objects/rotate.rs
+++ b/src/objects/rotate.rs
@@ -14,7 +14,7 @@ pub struct RotateY {
 }
 
 impl RotateY {
-    pub fn new(object: Arc<Hitable>, angle: Float) -> RotateY {
+    pub fn new(object: Arc<Hitable>, angle: Float) -> Hitable {
         // TODO: add proper time support
         let time_0: Float = 0.0;
         let time_1: Float = 1.0;
@@ -25,12 +25,12 @@ impl RotateY {
 
         match bounding_box {
             // No bounding box for object
-            None => RotateY {
+            None => Hitable::RotateY(RotateY {
                 object,
                 sin_theta,
                 cos_theta,
                 bounding_box: None,
-            },
+            }),
             // Got a bounding box
             Some(bbox) => {
                 let mut min: Vec3 = Vec3::new(Float::INFINITY, Float::INFINITY, Float::INFINITY);
@@ -64,12 +64,12 @@ impl RotateY {
                     }
                 }
 
-                RotateY {
+                Hitable::RotateY(RotateY {
                     object,
                     sin_theta,
                     cos_theta,
                     bounding_box: Some(AABB::new(min, max)),
-                }
+                })
             }
         }
     }

--- a/src/objects/rotate.rs
+++ b/src/objects/rotate.rs
@@ -7,14 +7,14 @@ use rand::prelude::*;
 use std::sync::Arc;
 
 pub struct RotateY {
-    object: Arc<dyn Hitable>,
+    object: Arc<Hitable>,
     sin_theta: Float,
     cos_theta: Float,
     bounding_box: Option<AABB>,
 }
 
 impl RotateY {
-    pub fn new(object: Arc<dyn Hitable>, angle: Float) -> RotateY {
+    pub fn new(object: Arc<Hitable>, angle: Float) -> RotateY {
         // TODO: add proper time support
         let time_0: Float = 0.0;
         let time_1: Float = 1.0;
@@ -73,10 +73,8 @@ impl RotateY {
             }
         }
     }
-}
 
-impl Hitable for RotateY {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &crate::ray::Ray,
         distance_min: Float,
@@ -129,7 +127,8 @@ impl Hitable for RotateY {
             }
         }
     }
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
+
+    pub fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
         self.bounding_box
     }
 }

--- a/src/objects/rotate.rs
+++ b/src/objects/rotate.rs
@@ -4,8 +4,10 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+#[derive(Deserialize, Serialize)]
 pub struct RotateY {
     object: Arc<Hitable>,
     sin_theta: Float,

--- a/src/objects/sphere.rs
+++ b/src/objects/sphere.rs
@@ -5,7 +5,9 @@ use crate::{
     Float, Vec3, PI,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
+#[derive(Deserialize, Serialize)]
 pub struct Sphere {
     center: Vec3,
     radius: Float,

--- a/src/objects/sphere.rs
+++ b/src/objects/sphere.rs
@@ -13,12 +13,12 @@ pub struct Sphere {
 }
 
 impl Sphere {
-    pub fn new(center: Vec3, radius: Float, material: Material) -> Self {
-        Sphere {
+    pub fn new(center: Vec3, radius: Float, material: Material) -> Hitable {
+        Hitable::Sphere(Sphere {
             center,
             radius,
             material,
-        }
+        })
     }
 
     // Returns the U,V surface coordinates of a hitpoint
@@ -30,10 +30,8 @@ impl Sphere {
         let v: Float = (theta + PI / 2.0) / PI;
         (u, v)
     }
-}
 
-impl Hitable for Sphere {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &Ray,
         distance_min: Float,
@@ -88,7 +86,7 @@ impl Hitable for Sphere {
         None
     }
 
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
+    pub fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
         let output_box = AABB::new(
             self.center - Vec3::new(self.radius, self.radius, self.radius),
             self.center + Vec3::new(self.radius, self.radius, self.radius),

--- a/src/objects/translate.rs
+++ b/src/objects/translate.rs
@@ -4,8 +4,10 @@ use crate::{
     Vec3,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+#[derive(Deserialize, Serialize)]
 pub struct Translate {
     object: Arc<Hitable>,
     offset: Vec3,

--- a/src/objects/translate.rs
+++ b/src/objects/translate.rs
@@ -7,21 +7,19 @@ use rand::prelude::*;
 use std::sync::Arc;
 
 pub struct Translate {
-    object: Arc<dyn Hitable>,
+    object: Arc<Hitable>,
     offset: Vec3,
 }
 
 impl Translate {
-    pub fn new(object: Arc<dyn Hitable>, offset: Vec3) -> Self {
-        Translate {
+    pub fn new(object: Arc<Hitable>, offset: Vec3) -> Hitable {
+        Hitable::Translate(Translate {
             object: Arc::clone(&object),
             offset,
-        }
+        })
     }
-}
 
-impl Hitable for Translate {
-    fn hit(
+    pub fn hit(
         &self,
         ray: &crate::ray::Ray,
         distance_min: crate::Float,
@@ -41,7 +39,8 @@ impl Hitable for Translate {
             }
         }
     }
-    fn bounding_box(&self, t0: crate::Float, t1: crate::Float) -> Option<AABB> {
+
+    pub fn bounding_box(&self, t0: crate::Float, t1: crate::Float) -> Option<AABB> {
         let object_bounding_box = self.object.bounding_box(t0, t1);
         match object_bounding_box {
             Some(aabb) => return Some(AABB::new(aabb.min + self.offset, aabb.max + self.offset)),

--- a/src/perlin.rs
+++ b/src/perlin.rs
@@ -125,3 +125,10 @@ impl Perlin {
         return accum.abs();
     }
 }
+
+impl Default for Perlin {
+    fn default() -> Self {
+        let rng = rand::thread_rng();
+        Perlin::new(rng)
+    }
+}

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,6 +1,7 @@
 use crate::{Float, Vec3};
 
 /// A Ray has an origin and a direction, as well as an instant in time it exists in. Motion blur is achieved by creating multiple rays with slightly different times.
+#[derive(Copy, Clone)]
 pub struct Ray {
     pub origin: Vec3,
     pub direction: Vec3,

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -5,6 +5,7 @@ use crate::{
     Float,
 };
 use rand::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub mod cornell;
 pub mod cornell_with_boxes;
@@ -18,6 +19,7 @@ pub mod random_scene;
 pub mod simple_light_lambertian;
 pub mod two_spheres;
 
+#[derive(Deserialize, Serialize)]
 pub struct Scene {
     pub world: Hitable, // BVHNode
     pub camera: Camera,

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -1,22 +1,22 @@
 use crate::{
     camera::Camera,
     color::Color,
-    hitable::{BVHNode, Hitable, HitableList},
+    hitable::{Hitable, HitableList},
     Float,
 };
 use rand::prelude::*;
 
-// pub mod cornell;
-// pub mod cornell_with_boxes;
-// pub mod cornell_with_smoke;
+pub mod cornell;
+pub mod cornell_with_boxes;
+pub mod cornell_with_smoke;
 pub mod cornell_with_sphere;
-// pub mod cornell_with_subsurface_sphere;
-// pub mod final_scene;
-// pub mod glass_spheres;
-// pub mod metal_spheres;
-// pub mod random_scene;
-// pub mod simple_light_lambertian;
-// pub mod two_spheres;
+pub mod cornell_with_subsurface_sphere;
+pub mod final_scene;
+pub mod glass_spheres;
+pub mod metal_spheres;
+pub mod random_scene;
+pub mod simple_light_lambertian;
+pub mod two_spheres;
 
 pub struct Scene {
     pub world: Hitable, // BVHNode

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -1,25 +1,25 @@
 use crate::{
     camera::Camera,
     color::Color,
-    hitable::{BVHNode, HitableList},
+    hitable::{BVHNode, Hitable, HitableList},
     Float,
 };
 use rand::prelude::*;
 
-pub mod cornell;
-pub mod cornell_with_boxes;
-pub mod cornell_with_smoke;
+// pub mod cornell;
+// pub mod cornell_with_boxes;
+// pub mod cornell_with_smoke;
 pub mod cornell_with_sphere;
-pub mod cornell_with_subsurface_sphere;
-pub mod final_scene;
-pub mod glass_spheres;
-pub mod metal_spheres;
-pub mod random_scene;
-pub mod simple_light_lambertian;
-pub mod two_spheres;
+// pub mod cornell_with_subsurface_sphere;
+// pub mod final_scene;
+// pub mod glass_spheres;
+// pub mod metal_spheres;
+// pub mod random_scene;
+// pub mod simple_light_lambertian;
+// pub mod two_spheres;
 
 pub struct Scene {
-    pub world: BVHNode,
+    pub world: Hitable, // BVHNode
     pub camera: Camera,
     pub background: Color, // TODO: make into Texture or something?
 }

--- a/src/scenes/cornell.rs
+++ b/src/scenes/cornell.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/cornell.rs
+++ b/src/scenes/cornell.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/cornell.rs
+++ b/src/scenes/cornell.rs
@@ -9,7 +9,7 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
+
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;

--- a/src/scenes/cornell.rs
+++ b/src/scenes/cornell.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -21,24 +21,12 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.hitables.push(Arc::new(XZRect::new(
-        113.0, 443.0, 127.0, 432.0, 554.0, light,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red));
+    world.add(XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
+    world.add(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_boxes.rs
+++ b/src/scenes/cornell_with_boxes.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world = HitableList::new().0;
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -23,46 +23,34 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.hitables.push(Arc::new(XZRect::new(
-        113.0, 443.0, 127.0, 432.0, 554.0, light,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.push((YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
+    world.push((YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
+    world.push((XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light)));
+    world.push((XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
+    world.push((XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.push((XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
 
     // Boxes
 
-    let box1 = Arc::new(Boxy::new(
+    let box1 = (Boxy::new(
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(165.0, 330.0, 165.0),
         white,
     ));
 
     let box1 = RotateY::new(box1, 15.0);
-    let box1 = Translate::new(Arc::new(box1), Vec3::new(265.0, 0.0, 295.0));
-    world.hitables.push(Arc::new(box1));
+    let box1 = Translate::new((box1), Vec3::new(265.0, 0.0, 295.0));
+    world.push((box1));
 
-    let box2 = Arc::new(Boxy::new(
+    let box2 = (Boxy::new(
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(165.0, 165.0, 165.0),
         white,
     ));
 
     let box2 = RotateY::new(box2, -18.0);
-    let box2 = Translate::new(Arc::new(box2), Vec3::new(130.0, 0.0, 65.0));
-    world.hitables.push(Arc::new(box2));
+    let box2 = Translate::new((box2), Vec3::new(130.0, 0.0, 65.0));
+    world.push((box2));
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_boxes.rs
+++ b/src/scenes/cornell_with_boxes.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/cornell_with_boxes.rs
+++ b/src/scenes/cornell_with_boxes.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world = HitableList::new().0;
+    let mut world = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -23,34 +23,34 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world.push((YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world.push((YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.push((XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light)));
-    world.push((XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world.push((XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world.push((XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red));
+    world.add(XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
+    world.add(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
 
     // Boxes
 
-    let box1 = (Boxy::new(
+    let box1 = Arc::new(Boxy::new(
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(165.0, 330.0, 165.0),
         white,
     ));
 
     let box1 = RotateY::new(box1, 15.0);
-    let box1 = Translate::new((box1), Vec3::new(265.0, 0.0, 295.0));
-    world.push((box1));
+    let box1 = Translate::new(Arc::new(box1), Vec3::new(265.0, 0.0, 295.0));
+    world.add(box1);
 
-    let box2 = (Boxy::new(
+    let box2 = Arc::new(Boxy::new(
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(165.0, 165.0, 165.0),
         white,
     ));
 
     let box2 = RotateY::new(box2, -18.0);
-    let box2 = Translate::new((box2), Vec3::new(130.0, 0.0, 65.0));
-    world.push((box2));
+    let box2 = Translate::new(Arc::new(box2), Vec3::new(130.0, 0.0, 65.0));
+    world.add(box2);
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_smoke.rs
+++ b/src/scenes/cornell_with_smoke.rs
@@ -22,24 +22,12 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.hitables.push(Arc::new(XZRect::new(
-        113.0, 443.0, 127.0, 432.0, 554.0, light,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red));
+    world.add(XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
+    world.add(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
 
     // Boxes
 
@@ -71,8 +59,8 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
         SolidColor::new(Color::new(1.0, 1.0, 1.0)),
     );
 
-    world.hitables.push(Arc::new(box1));
-    world.hitables.push(Arc::new(box2));
+    world.add(box1);
+    world.add(box2);
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_smoke.rs
+++ b/src/scenes/cornell_with_smoke.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/cornell_with_smoke.rs
+++ b/src/scenes/cornell_with_smoke.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/cornell_with_sphere.rs
+++ b/src/scenes/cornell_with_sphere.rs
@@ -2,7 +2,7 @@ use super::Scene;
 use crate::{
     camera::Camera,
     color::Color,
-    hitable::{Hitable, HitableList},
+    hitable::HitableList,
     materials::{Dielectric, DiffuseLight, Lambertian},
     objects::Sphere,
     objects::{XYRect, XZRect, YZRect},
@@ -10,7 +10,7 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
+
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;

--- a/src/scenes/cornell_with_sphere.rs
+++ b/src/scenes/cornell_with_sphere.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -42,7 +42,7 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
         .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
 
     // glass sphere
-    let sphere: Arc<dyn Hitable> = Arc::new(Sphere::new(
+    let sphere: Arc<Hitable> = Arc::new(Sphere::new(
         Vec3::new(278.0, 278.0, 278.0),
         120.0,
         Dielectric::new(1.5),

--- a/src/scenes/cornell_with_sphere.rs
+++ b/src/scenes/cornell_with_sphere.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -22,32 +22,16 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.hitables.push(Arc::new(XZRect::new(
-        113.0, 443.0, 127.0, 432.0, 554.0, light,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red));
+    world.add(XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
+    world.add(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
 
     // glass sphere
-    let sphere: Arc<Hitable> = Arc::new(Sphere::new(
-        Vec3::new(278.0, 278.0, 278.0),
-        120.0,
-        Dielectric::new(1.5),
-    ));
-    world.hitables.push(Arc::clone(&sphere));
+    let sphere = Sphere::new(Vec3::new(278.0, 278.0, 278.0), 120.0, Dielectric::new(1.5));
+    world.add(sphere);
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_subsurface_sphere.rs
+++ b/src/scenes/cornell_with_subsurface_sphere.rs
@@ -2,7 +2,7 @@ use super::Scene;
 use crate::{
     camera::Camera,
     color::Color,
-    hitable::{Hitable, HitableList},
+    hitable::HitableList,
     materials::{Dielectric, DiffuseLight, Lambertian},
     objects::{ConstantMedium, Sphere},
     objects::{XYRect, XZRect, YZRect},
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -22,39 +22,24 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let green = Lambertian::new(SolidColor::new(Color::new(0.12, 0.45, 0.15)));
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
 
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green)));
-    world
-        .hitables
-        .push(Arc::new(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red)));
-    world.hitables.push(Arc::new(XZRect::new(
-        113.0, 443.0, 127.0, 432.0, 554.0, light,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, green));
+    world.add(YZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, red));
+    world.add(XZRect::new(113.0, 443.0, 127.0, 432.0, 554.0, light));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 0.0, white));
+    world.add(XZRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
+    world.add(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white));
 
     // glass sphere
-    let sphere: Arc<Hitable> = Arc::new(Sphere::new(
-        Vec3::new(278.0, 278.0, 278.0),
-        120.0,
-        Dielectric::new(1.5),
-    ));
-    world.hitables.push(Arc::clone(&sphere));
+    let glass_sphere = Sphere::new(Vec3::new(278.0, 278.0, 278.0), 120.0, Dielectric::new(1.5));
+    world.add(glass_sphere);
     // blue subsurface reflection
-    let sphere2: Arc<Hitable> = Arc::new(ConstantMedium::new(
-        Arc::clone(&sphere),
+    let blue_smoke = Sphere::new(Vec3::new(278.0, 278.0, 278.0), 120.0, Dielectric::new(1.5));
+    let sphere2 = ConstantMedium::new(
+        Arc::new(blue_smoke),
         0.2,
         SolidColor::new(Color::new(0.2, 0.4, 0.9)),
-    ));
-    world.hitables.push(sphere2);
+    );
+    world.add(sphere2);
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/cornell_with_subsurface_sphere.rs
+++ b/src/scenes/cornell_with_subsurface_sphere.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));
@@ -42,14 +42,14 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
         .push(Arc::new(XYRect::new(0.0, 555.0, 0.0, 555.0, 555.0, white)));
 
     // glass sphere
-    let sphere: Arc<dyn Hitable> = Arc::new(Sphere::new(
+    let sphere: Arc<Hitable> = Arc::new(Sphere::new(
         Vec3::new(278.0, 278.0, 278.0),
         120.0,
         Dielectric::new(1.5),
     ));
     world.hitables.push(Arc::clone(&sphere));
     // blue subsurface reflection
-    let sphere2: Arc<dyn Hitable> = Arc::new(ConstantMedium::new(
+    let sphere2: Arc<Hitable> = Arc::new(ConstantMedium::new(
         Arc::clone(&sphere),
         0.2,
         SolidColor::new(Color::new(0.2, 0.4, 0.9)),

--- a/src/scenes/cornell_with_subsurface_sphere.rs
+++ b/src/scenes/cornell_with_subsurface_sphere.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     // Cornell box
     let red = Lambertian::new(SolidColor::new(Color::new(0.65, 0.05, 0.05)));

--- a/src/scenes/final_scene.rs
+++ b/src/scenes/final_scene.rs
@@ -23,7 +23,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let time_1: Float = 1.0;
 
     // Ground: lots of boxes
-    let mut boxes1: HitableList = HitableList::new();
+    let mut boxes1: Arc<Hitable>List = HitableList::new();
     let ground: Material = Lambertian::new(SolidColor::new(Color::new(0.48, 0.83, 0.53)));
 
     let boxes_per_side = 20;
@@ -45,7 +45,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
         }
     }
 
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     world
         .hitables
@@ -83,7 +83,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     )));
 
     // blue glass sphere
-    let boundary: Arc<dyn Hitable> = Arc::new(Sphere::new(
+    let boundary: Arc<Hitable> = Arc::new(Sphere::new(
         Vec3::new(360.0, 150.0, 145.0),
         70.0,
         Dielectric::new(1.5),
@@ -111,7 +111,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     )));
 
     // Sphere-rasterized pseudo-box
-    let mut boxes2: HitableList = HitableList::new();
+    let mut boxes2: Arc<Hitable>List = HitableList::new();
     let white = Lambertian::new(SolidColor::new(Color::new(0.73, 0.73, 0.73)));
     let num_spheres = 1000;
     for _j in 0..num_spheres {

--- a/src/scenes/final_scene.rs
+++ b/src/scenes/final_scene.rs
@@ -23,7 +23,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let time_1: Float = 1.0;
 
     // Ground: lots of boxes
-    let mut boxes1: Arc<Hitable>List = HitableList::new();
+    let mut boxes1: HitableList = HitableList::new();
     let ground: Material = Lambertian::new(SolidColor::new(Color::new(0.48, 0.83, 0.53)));
 
     let boxes_per_side = 20;
@@ -45,7 +45,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
         }
     }
 
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     world
         .hitables
@@ -111,7 +111,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     )));
 
     // Sphere-rasterized pseudo-box
-    let mut boxes2: Arc<Hitable>List = HitableList::new();
+    let mut boxes2: HitableList = HitableList::new();
     let white = Lambertian::new(SolidColor::new(Color::new(0.73, 0.73, 0.73)));
     let num_spheres = 1000;
     for _j in 0..num_spheres {

--- a/src/scenes/final_scene.rs
+++ b/src/scenes/final_scene.rs
@@ -2,7 +2,7 @@ use super::Scene;
 use crate::{
     camera::Camera,
     color::Color,
-    hitable::{Hitable, HitableList},
+    hitable::HitableList,
     materials::{Dielectric, DiffuseLight, Lambertian, Material, Metal},
     objects::XZRect,
     objects::{
@@ -37,85 +37,78 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
             let y1: Float = rng.gen_range(1.0, 101.0);
             let z1: Float = z0 + w;
 
-            boxes1.hitables.push(Arc::new(Boxy::new(
+            boxes1.add(Boxy::new(
                 Vec3::new(x0, y0, z0),
                 Vec3::new(x1, y1, z1),
                 ground,
-            )));
+            ));
         }
     }
 
     let mut world: HitableList = HitableList::new();
 
-    world
-        .hitables
-        .push(Arc::new(boxes1.into_bvh(time_0, time_1, rng)));
+    world.add(boxes1.into_bvh(time_0, time_1, rng));
 
     let light = DiffuseLight::new(SolidColor::new(Color::new(7.0, 7.0, 7.0)));
-    world.hitables.push(Arc::new(XZRect::new(
-        123.0, 423.0, 147.0, 412.0, 554.0, light,
-    )));
+    world.add(XZRect::new(123.0, 423.0, 147.0, 412.0, 554.0, light));
 
     let center1 = Vec3::new(400.0, 400.0, 200.0);
     let center2 = center1 + Vec3::new(30.0, 0.0, 0.0);
     let moving_sphere_material = Lambertian::new(SolidColor::new(Color::new(0.7, 0.3, 0.1)));
-    world.hitables.push(Arc::new(MovingSphere::new(
+    world.add(MovingSphere::new(
         center1,
         center2,
         time_0,
         time_1,
         50.0,
         moving_sphere_material,
-    )));
+    ));
 
     // clear glass sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(260.0, 150.0, 45.0),
         50.0,
         Dielectric::new(1.5),
-    )));
+    ));
 
     // half-matte metal sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, 150.0, 145.0),
         50.0,
         Metal::new(SolidColor::new(Color::new(0.8, 0.8, 0.9)), 10.0),
-    )));
-
-    // blue glass sphere
-    let boundary: Arc<Hitable> = Arc::new(Sphere::new(
-        Vec3::new(360.0, 150.0, 145.0),
-        70.0,
-        Dielectric::new(1.5),
     ));
-    world.hitables.push(Arc::clone(&boundary));
-    world.hitables.push(Arc::new(ConstantMedium::new(
-        Arc::clone(&boundary),
+
+    // blue glass sphere in two parts: glass & subsurface reflection
+    let glass_sphere = Sphere::new(Vec3::new(360.0, 150.0, 145.0), 70.0, Dielectric::new(1.5));
+    world.add(glass_sphere);
+    let blue_smoke = Sphere::new(Vec3::new(360.0, 150.0, 145.0), 70.0, Dielectric::new(1.5));
+    world.add(ConstantMedium::new(
+        Arc::new(blue_smoke),
         0.2,
         SolidColor::new(Color::new(0.2, 0.4, 0.9)),
-    )));
+    ));
     // overall boundary sphere, big and misty inside
     let boundary2 = Sphere::new(Vec3::new(0.0, 0.0, 0.0), 5000.0, Dielectric::new(1.5));
-    world.hitables.push(Arc::new(ConstantMedium::new(
+    world.add(ConstantMedium::new(
         Arc::new(boundary2),
         0.0001,
         SolidColor::new(Color::new(1.0, 1.0, 1.0)),
-    )));
+    ));
 
     // noise / marble sphere
     let pertext = NoiseTexture::new(Perlin::new(rng), 2.0);
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(220.0, 280.0, 300.0),
         80.0,
         Lambertian::new(pertext),
-    )));
+    ));
 
     // Sphere-rasterized pseudo-box
     let mut boxes2: HitableList = HitableList::new();
     let white = Lambertian::new(SolidColor::new(Color::new(0.73, 0.73, 0.73)));
     let num_spheres = 1000;
     for _j in 0..num_spheres {
-        boxes2.hitables.push(Arc::new(Sphere::new(
+        boxes2.add(Sphere::new(
             Vec3::new(
                 rng.gen_range(0.0, 165.0),
                 rng.gen_range(0.0, 165.0),
@@ -123,16 +116,16 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
             ),
             10.0,
             white,
-        )));
+        ));
     }
 
-    world.hitables.push(Arc::new(Translate::new(
+    world.add(Translate::new(
         Arc::new(RotateY::new(
             Arc::new(boxes2.into_bvh(time_0, time_1, rng)),
             15.0,
         )),
         Vec3::new(-100.0, 270.0, 395.0),
-    )));
+    ));
 
     let camera_position: Vec3 = Vec3::new(278.0, 278.0, -800.0);
     let camera_target: Vec3 = Vec3::new(278.0, 278.0, 0.0);

--- a/src/scenes/glass_spheres.rs
+++ b/src/scenes/glass_spheres.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     // blue middle sphere
     world.hitables.push(Arc::new(Sphere::new(

--- a/src/scenes/glass_spheres.rs
+++ b/src/scenes/glass_spheres.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     // blue middle sphere
     world.hitables.push(Arc::new(Sphere::new(

--- a/src/scenes/glass_spheres.rs
+++ b/src/scenes/glass_spheres.rs
@@ -9,38 +9,38 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
+
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
     let mut world: HitableList = HitableList::new();
 
     // blue middle sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, 0.0, -1.0),
         0.5,
         Lambertian::new(SolidColor::new(Color::new(0.1, 0.2, 0.5))),
-    )));
+    ));
 
     // large green ground sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, -100.5, -1.0),
         100.0,
         Lambertian::new(SolidColor::new(Color::new(0.8, 0.8, 0.0))),
-    )));
+    ));
 
     // metal sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(1.0, 0.0, -1.0),
         0.5,
         Metal::new(SolidColor::new(Color::new(0.8, 0.6, 0.2)), 0.0),
-    )));
+    ));
     // glass sphere
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(-1.0, 0.0, -1.0),
         0.5,
         Dielectric::new(1.5),
-    )));
+    ));
 
     let camera_position: Vec3 = Vec3::new(0.0, 0.0, 5.0);
     let camera_target: Vec3 = Vec3::new(0.0, 0.0, -1.0);

--- a/src/scenes/metal_spheres.rs
+++ b/src/scenes/metal_spheres.rs
@@ -9,35 +9,34 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
 
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
     let mut world: HitableList = HitableList::new();
 
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, 0.0, -1.0),
         0.5,
         Lambertian::new(SolidColor::new(Color::new(0.7, 0.3, 0.3))),
-    )));
+    ));
 
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, -100.5, -1.0),
         100.0,
         Lambertian::new(SolidColor::new(Color::new(0.8, 0.8, 0.0))),
-    )));
+    ));
 
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(1.0, 0.0, -1.0),
         0.5,
         Metal::new(SolidColor::new(Color::new(0.8, 0.6, 0.2)), 0.3),
-    )));
-    world.hitables.push(Arc::new(Sphere::new(
+    ));
+    world.add(Sphere::new(
         Vec3::new(-1.0, 0.0, -1.0),
         0.5,
         Metal::new(SolidColor::new(Color::new(0.8, 0.8, 0.8)), 1.0),
-    )));
+    ));
 
     let camera_position: Vec3 = Vec3::new(0.0, 0.0, 5.0);
     let camera_target: Vec3 = Vec3::new(0.0, 0.0, -1.0);

--- a/src/scenes/metal_spheres.rs
+++ b/src/scenes/metal_spheres.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     world.hitables.push(Arc::new(Sphere::new(
         Vec3::new(0.0, 0.0, -1.0),

--- a/src/scenes/metal_spheres.rs
+++ b/src/scenes/metal_spheres.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     world.hitables.push(Arc::new(Sphere::new(
         Vec3::new(0.0, 0.0, -1.0),

--- a/src/scenes/random_scene.rs
+++ b/src/scenes/random_scene.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     let ground_color1 = Color::new(0.2, 0.3, 0.1);
     let ground_color2 = Color::new(0.9, 0.9, 0.9);

--- a/src/scenes/random_scene.rs
+++ b/src/scenes/random_scene.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     let ground_color1 = Color::new(0.2, 0.3, 0.1);
     let ground_color2 = Color::new(0.9, 0.9, 0.9);

--- a/src/scenes/random_scene.rs
+++ b/src/scenes/random_scene.rs
@@ -9,7 +9,6 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
 
 pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
@@ -21,7 +20,7 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
     let ground_texture = Checkered::new(ground_color1, ground_color2, 10.0);
     let ground_material = Lambertian::new(ground_texture);
     let ground_sphere = Sphere::new(Vec3::new(0.0, -1000.0, 0.0), 1000.0, ground_material);
-    world.hitables.push(Arc::new(ground_sphere));
+    world.add(ground_sphere);
 
     for a in -11..11 {
         for b in -11..11 {
@@ -39,54 +38,38 @@ pub fn load(width: u32, height: u32, mut rng: ThreadRng) -> Scene {
                     let texture = SolidColor::new(color);
                     let sphere_material = Lambertian::new(texture);
                     let center2 = center + Vec3::new(0.0, rng.gen_range(0.0, 0.5), 0.0);
-                    world.hitables.push(Arc::new(MovingSphere::new(
+                    world.add(MovingSphere::new(
                         center,
                         center2,
                         time_0,
                         time_1,
                         0.2,
                         sphere_material,
-                    )));
+                    ));
                 } else if choose_mat < 0.95 {
                     // metal
                     let color = Color::random(rng);
                     let texture = SolidColor::new(color);
                     let fuzz = rng.gen_range(0.0, 0.5);
                     let sphere_material = Metal::new(texture, fuzz);
-                    world
-                        .hitables
-                        .push(Arc::new(Sphere::new(center, 0.2, sphere_material)));
+                    world.add(Sphere::new(center, 0.2, sphere_material));
                 } else {
                     // glass
                     let sphere_material = Dielectric::new(1.5);
-                    world
-                        .hitables
-                        .push(Arc::new(Sphere::new(center, 0.2, sphere_material)));
+                    world.add(Sphere::new(center, 0.2, sphere_material));
                 }
             }
         }
     }
 
     let material1 = Dielectric::new(1.5);
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(0.0, 1.0, 0.0),
-        1.0,
-        material1,
-    )));
+    world.add(Sphere::new(Vec3::new(0.0, 1.0, 0.0), 1.0, material1));
 
     let material2 = Lambertian::new(SolidColor::new(Color::new(0.4, 0.2, 0.1)));
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(-4.0, 1.0, 0.0),
-        1.0,
-        material2,
-    )));
+    world.add(Sphere::new(Vec3::new(-4.0, 1.0, 0.0), 1.0, material2));
 
     let material3 = Metal::new(SolidColor::new(Color::new(0.7, 0.6, 0.5)), 0.0);
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(4.0, 1.0, 0.0),
-        1.0,
-        material3,
-    )));
+    world.add(Sphere::new(Vec3::new(4.0, 1.0, 0.0), 1.0, material3));
 
     let camera_position: Vec3 = Vec3::new(13.0, 2.0, 3.0);
     let camera_target: Vec3 = Vec3::new(0.0, 0.0, 0.0);

--- a/src/scenes/simple_light_lambertian.rs
+++ b/src/scenes/simple_light_lambertian.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     let texture: Texture = SolidColor::new(Color::new(0.3, 0.2, 0.1));
     let texture2: Texture = SolidColor::new(Color::new(0.1, 0.2, 0.3));

--- a/src/scenes/simple_light_lambertian.rs
+++ b/src/scenes/simple_light_lambertian.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     let texture: Texture = SolidColor::new(Color::new(0.3, 0.2, 0.1));
     let texture2: Texture = SolidColor::new(Color::new(0.1, 0.2, 0.3));

--- a/src/scenes/simple_light_lambertian.rs
+++ b/src/scenes/simple_light_lambertian.rs
@@ -10,7 +10,6 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
 
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
@@ -20,26 +19,20 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let texture: Texture = SolidColor::new(Color::new(0.3, 0.2, 0.1));
     let texture2: Texture = SolidColor::new(Color::new(0.1, 0.2, 0.3));
 
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, -1000.0, 0.0),
         1000.0,
         Lambertian::new(texture),
-    )));
-    world.hitables.push(Arc::new(Sphere::new(
+    ));
+    world.add(Sphere::new(
         Vec3::new(0.0, 2.0, 0.0),
         2.0,
         Lambertian::new(texture2),
-    )));
+    ));
 
     let difflight: Material = DiffuseLight::new(SolidColor::new(Color::new(4.0, 4.0, 4.0)));
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(0.0, 7.0, 0.0),
-        2.0,
-        difflight,
-    )));
-    world
-        .hitables
-        .push(Arc::new(XYRect::new(3.0, 5.0, 1.0, 3.0, -2.0, difflight)));
+    world.add(Sphere::new(Vec3::new(0.0, 7.0, 0.0), 2.0, difflight));
+    world.add(XYRect::new(3.0, 5.0, 1.0, 3.0, -2.0, difflight));
 
     let camera_position: Vec3 = Vec3::new(20.0, 5.0, 2.0);
     let camera_target: Vec3 = Vec3::new(0.0, 2.0, 0.0);

--- a/src/scenes/simple_light_perlin.rs
+++ b/src/scenes/simple_light_perlin.rs
@@ -20,33 +20,30 @@ pub fn load<'a>(width: u32, height: u32, rng: ThreadRng) -> Scene<'a> {
     let perlin = Perlin::new(256, rng);
     let perlin2 = Perlin::new(256, rng);
 
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(0.0, -1000.0, 0.0),
-        1000.0,
-        Arc::new(Lambertian::new(Arc::new(NoiseTexture::new(perlin, 4.0)))),
-    )));
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(0.0, 2.0, 0.0),
-        2.0,
-        Arc::new(Lambertian::new(Arc::new(NoiseTexture::new(perlin2, 4.0)))),
-    )));
+    world.add(
+        (Sphere::new(
+            Vec3::new(0.0, -1000.0, 0.0),
+            1000.0,
+            Arc::new(Lambertian::new(Arc::new(NoiseTexture::new(perlin, 4.0)))),
+        )),
+    );
+    world.add(
+        (Sphere::new(
+            Vec3::new(0.0, 2.0, 0.0),
+            2.0,
+            Arc::new(Lambertian::new(Arc::new(NoiseTexture::new(perlin2, 4.0)))),
+        )),
+    );
 
     let difflight: Arc<dyn Material> = Arc::new(DiffuseLight::new(Arc::new(SolidColor::new(
         Color::new(4.0, 4.0, 4.0),
     ))));
-    world.hitables.push(Arc::new(Sphere::new(
-        Vec3::new(0.0, 7.0, 0.0),
-        2.0,
-        Arc::clone(&difflight),
-    )));
-    world.hitables.push(Arc::new(XYRect::new(
-        3.0,
-        5.0,
-        1.0,
-        3.0,
-        -2.0,
-        Arc::clone(&difflight),
-    )));
+    world
+        .hitables
+        .add((Sphere::new(Vec3::new(0.0, 7.0, 0.0), 2.0, Arc::clone(&difflight))));
+    world
+        .hitables
+        .add((XYRect::new(3.0, 5.0, 1.0, 3.0, -2.0, Arc::clone(&difflight))));
 
     let camera_position: Vec3 = Vec3::new(20.0, 5.0, 2.0);
     let camera_target: Vec3 = Vec3::new(0.0, 2.0, 0.0);

--- a/src/scenes/simple_light_perlin.rs
+++ b/src/scenes/simple_light_perlin.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load<'a>(width: u32, height: u32, rng: ThreadRng) -> Scene<'a> {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     let perlin = Perlin::new(256, rng);
     let perlin2 = Perlin::new(256, rng);

--- a/src/scenes/simple_light_perlin.rs
+++ b/src/scenes/simple_light_perlin.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn load<'a>(width: u32, height: u32, rng: ThreadRng) -> Scene<'a> {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     let perlin = Perlin::new(256, rng);
     let perlin2 = Perlin::new(256, rng);

--- a/src/scenes/two_spheres.rs
+++ b/src/scenes/two_spheres.rs
@@ -9,7 +9,6 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::*;
-use std::sync::Arc;
 
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
@@ -19,16 +18,16 @@ pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let checker: Texture =
         Checkered::new(Color::new(0.2, 0.3, 0.1), Color::new(0.9, 0.9, 0.9), 10.0);
 
-    world.hitables.push(Arc::new(Sphere::new(
+    world.add(Sphere::new(
         Vec3::new(0.0, -10.0, 0.0),
         10.0,
         Lambertian::new(checker),
-    )));
-    world.hitables.push(Arc::new(Sphere::new(
+    ));
+    world.add(Sphere::new(
         Vec3::new(0.0, 10.0, 0.0),
         10.0,
         Lambertian::new(checker),
-    )));
+    ));
 
     let camera_position: Vec3 = Vec3::new(13.0, 2.0, 3.0);
     let camera_target: Vec3 = Vec3::new(0.0, 0.0, 0.0);

--- a/src/scenes/two_spheres.rs
+++ b/src/scenes/two_spheres.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: Arc<Hitable>List = HitableList::new();
+    let mut world: HitableList = HitableList::new();
 
     let checker: Texture =
         Checkered::new(Color::new(0.2, 0.3, 0.1), Color::new(0.9, 0.9, 0.9), 10.0);

--- a/src/scenes/two_spheres.rs
+++ b/src/scenes/two_spheres.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub fn load(width: u32, height: u32, rng: ThreadRng) -> Scene {
     let time_0: Float = 0.0;
     let time_1: Float = 1.0;
-    let mut world: HitableList = HitableList::new();
+    let mut world: Arc<Hitable>List = HitableList::new();
 
     let checker: Texture =
         Checkered::new(Color::new(0.2, 0.3, 0.1), Color::new(0.9, 0.9, 0.9), 10.0);

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -11,10 +11,6 @@ pub use solid_color::*;
 use crate::{color::Color, Float, Vec3};
 use noise_texture::NoiseTexture;
 
-// pub trait Texture: Sync + Send {
-//     fn color(&self, u: Float, v: Float, position: Vec3) -> Color;
-// }
-
 #[derive(Copy, Clone, Deserialize, Serialize)]
 pub enum Texture {
     Checkered(Checkered),

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub mod checkered;
 pub mod noise_texture;
 pub mod solid_color;
@@ -13,7 +15,7 @@ use noise_texture::NoiseTexture;
 //     fn color(&self, u: Float, v: Float, position: Vec3) -> Color;
 // }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub enum Texture {
     Checkered(Checkered),
     SolidColor(SolidColor),

--- a/src/textures/checkered.rs
+++ b/src/textures/checkered.rs
@@ -1,7 +1,9 @@
-use super::{Texture};
+use serde::{Deserialize, Serialize};
+
+use super::Texture;
 use crate::{color::Color, Float, Vec3};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct Checkered {
     // TODO: get recursive textures back, maybe?
     even: Color,

--- a/src/textures/noise_texture.rs
+++ b/src/textures/noise_texture.rs
@@ -1,9 +1,12 @@
+use serde::{Deserialize, Serialize};
+
 use super::Texture;
 use crate::{color::Color, perlin::Perlin, Float, Vec3};
 
 // TODO: This might be currently oddly broken and resulting in overflowy surfaces
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct NoiseTexture {
+    #[serde(skip)]
     noise: Perlin,
     scale: Float,
 }

--- a/src/textures/solid_color.rs
+++ b/src/textures/solid_color.rs
@@ -1,7 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 use super::Texture;
 use crate::{color::Color, Float, Vec3};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct SolidColor {
     pub color: Color,
 }


### PR DESCRIPTION
This branch started as an attempt to get `serde`'s fantastic `Deserialize` and `Serialize` working. While those goals aren't met yet, this pull request makes `Hitable` into an enum instead of the `dyn Trait` it used to be. In addition, there's significant simplifications into how scenes are constructed, and I think some unnecessary `Arc`s removed.

This PR seems to bring such a massive performance improvement (especially on high-corecount machines) that I'm merging this even if it doesn't fulfill the original branch name's purpose.