### PR TITLE
Bring back ConstantMedium smoke objects

### DIFF
--- a/scenes/cornell_with_smoke.json
+++ b/scenes/cornell_with_smoke.json
@@ -1,0 +1,301 @@
+{
+  "time_0": 0.0,
+  "time_1": 1.0,
+  "camera": {
+    "look_from": [
+      278.0,
+      278.0,
+      -800.0
+    ],
+    "look_at": [
+      278.0,
+      278.0,
+      0.0
+    ],
+    "up": [
+      0.0,
+      1.0,
+      0.0
+    ],
+    "vertical_fov": 40.0,
+    "aperture": 0.0,
+    "focus_distance": 10.0
+  },
+  "background_color": [
+    0.0,
+    0.0,
+    0.0
+  ],
+  "objects": [
+    {
+      "YZRect": {
+        "y0": 0.0,
+        "y1": 555.0,
+        "z0": 0.0,
+        "z1": 555.0,
+        "k": 555.0,
+        "material": {
+          "Lambertian": {
+            "albedo": {
+              "SolidColor": {
+                "color": [
+                  0.12,
+                  0.45,
+                  0.15
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "YZRect": {
+        "y0": 0.0,
+        "y1": 555.0,
+        "z0": 0.0,
+        "z1": 555.0,
+        "k": 0.0,
+        "material": {
+          "Lambertian": {
+            "albedo": {
+              "SolidColor": {
+                "color": [
+                  0.65,
+                  0.05,
+                  0.05
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "XZRect": {
+        "x0": 0.0,
+        "x1": 555.0,
+        "z0": 0.0,
+        "z1": 555.0,
+        "k": 0.0,
+        "material": {
+          "Lambertian": {
+            "albedo": {
+              "SolidColor": {
+                "color": [
+                  0.73,
+                  0.73,
+                  0.73
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "XZRect": {
+        "x0": 0.0,
+        "x1": 555.0,
+        "z0": 0.0,
+        "z1": 555.0,
+        "k": 555.0,
+        "material": {
+          "Lambertian": {
+            "albedo": {
+              "SolidColor": {
+                "color": [
+                  0.73,
+                  0.73,
+                  0.73
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "XYRect": {
+        "x0": 0.0,
+        "x1": 555.0,
+        "y0": 0.0,
+        "y1": 555.0,
+        "k": 555.0,
+        "material": {
+          "Lambertian": {
+            "albedo": {
+              "SolidColor": {
+                "color": [
+                  0.73,
+                  0.73,
+                  0.73
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "FlipFace": {
+        "object": {
+          "XZRect": {
+            "x0": 213.0,
+            "x1": 343.0,
+            "z0": 227.0,
+            "z1": 332.0,
+            "k": 554.0,
+            "material": {
+              "DiffuseLight": {
+                "emit": {
+                  "SolidColor": {
+                    "color": [
+                      15.0,
+                      15.0,
+                      15.0
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "ConstantMedium": {
+        "boundary": {
+          "Translate": {
+            "offset": [
+              265.0,
+              0.0,
+              295.0
+            ],
+            "object": {
+              "RotateY": {
+                "angle": 15.0,
+                "object": {
+                  "Boxy": {
+                    "corner_0": [
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "corner_1": [
+                      165.0,
+                      330.0,
+                      165.0
+                    ],
+                    "material": {
+                      "Lambertian": {
+                        "albedo": {
+                          "SolidColor": {
+                            "color": [
+                              0.73,
+                              0.73,
+                              0.73
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "density": 0.01,
+        "texture": {
+          "SolidColor": {
+            "color": [
+              0.0,
+              0.0,
+              0.0
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ConstantMedium": {
+        "boundary": {
+          "Translate": {
+            "offset": [
+              130.0,
+              0.0,
+              65.0
+            ],
+            "object": {
+              "RotateY": {
+                "angle": -18.0,
+                "object": {
+                  "Boxy": {
+                    "corner_0": [
+                      0.0,
+                      0.0,
+                      0.0
+                    ],
+                    "corner_1": [
+                      165.0,
+                      165.0,
+                      165.0
+                    ],
+                    "material": {
+                      "Lambertian": {
+                        "albedo": {
+                          "SolidColor": {
+                            "color": [
+                              0.73,
+                              0.73,
+                              0.73
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "density": 0.01,
+        "texture": {
+          "SolidColor": {
+            "color": [
+              1.0,
+              1.0,
+              1.0
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "priority_objects": [
+    {
+      "XZRect": {
+        "x0": 213.0,
+        "x1": 343.0,
+        "z0": 227.0,
+        "z1": 332.0,
+        "k": 554.0,
+        "material": {
+          "DiffuseLight": {
+            "emit": {
+              "SolidColor": {
+                "color": [
+                  15.0,
+                  15.0,
+                  15.0
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -34,7 +34,8 @@ impl Material {
             Material::DiffuseLight(d) => DiffuseLight::scatter(d, ray, hit_record, rng),
             Material::Metal(m) => Metal::scatter(m, ray, hit_record, rng),
             Material::Dielectric(d) => Dielectric::scatter(d, ray, hit_record, rng),
-            _ => todo!(), // Material::Isotropic(i) => Isotropic::scatter(i, ray, hit_record, rng),
+            Material::Isotropic(i) => Isotropic::scatter(i, ray, hit_record, rng),
+            _ => todo!(),
         }
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,4 +1,4 @@
-use crate::{hitable::Hitable, Float, Vec3};
+use crate::{hitable::Hitable, textures::Texture, Float, Vec3};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -32,6 +32,7 @@ pub enum Object {
     RotateY(RotateInit),
     Translate(TranslateInit),
     FlipFace(FlipFaceInit),
+    ConstantMedium(ConstantMediumInit),
 }
 
 impl From<Object> for Hitable {
@@ -57,6 +58,11 @@ impl From<Object> for Hitable {
                 let obj: Hitable = obj.into();
                 FlipFace::new(obj)
             }
+            Object::ConstantMedium(x) => {
+                let obj = *x.boundary;
+                let obj: Hitable = obj.into();
+                ConstantMedium::new(Arc::new(obj), x.density, *x.texture)
+            }
         }
     }
 }
@@ -75,4 +81,11 @@ pub struct RotateInit {
 pub struct TranslateInit {
     object: Box<Object>,
     offset: Vec3,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstantMediumInit {
+    boundary: Box<Object>,
+    density: Float,
+    texture: Box<Texture>,
 }


### PR DESCRIPTION
Potentially fix isotropic materials & constantmedium objects, as these were missing / broken with other changes in Book 3.
Correctness may be shaky, but it seems to work.

![scene](https://user-images.githubusercontent.com/2943750/95692516-fa29bb80-0c2e-11eb-9e8d-6e8d47c2bf63.png)
