### PR TITLE
Fix up `tracing-timing` integration

### DIFF
--- a/clovers/src/draw.rs
+++ b/clovers/src/draw.rs
@@ -15,6 +15,8 @@ pub fn draw(
     scene: Scene,
 ) -> Vec<Color> {
     // Progress bar
+    let span = span!(Level::TRACE, "draw");
+    let _enter = span.enter();
     let pixels = (width * height) as u64;
     let bar = ProgressBar::new(pixels);
     bar.set_draw_delta(pixels / 1000);
@@ -29,8 +31,8 @@ pub fn draw(
         .par_iter_mut()
         .enumerate()
         .for_each(|(index, pixel)| {
-            let span = span!(Level::TRACE, "draw", index, ?pixel);
-            let _enter = span.enter();
+            let _e = span.enter();
+            let _e = trace_span!("draw_pixel", index, ?pixel).entered();
             let x = index % width as usize;
             let y = index / width as usize;
             let rng = rand::thread_rng();

--- a/clovers/src/draw.rs
+++ b/clovers/src/draw.rs
@@ -14,9 +14,6 @@ pub fn draw(
     gamma: Float,
     scene: Scene,
 ) -> Vec<Color> {
-    let span = span!(Level::TRACE, "draw");
-    let _enter = span.enter();
-
     // Progress bar
     let pixels = (width * height) as u64;
     let bar = ProgressBar::new(pixels);
@@ -32,6 +29,7 @@ pub fn draw(
         .par_iter_mut()
         .enumerate()
         .for_each(|(index, pixel)| {
+            let span = span!(Level::TRACE, "draw", index, ?pixel);
             let _enter = span.enter();
             let x = index % width as usize;
             let y = index / width as usize;


### PR DESCRIPTION
This makes the following changes:
- Call `TimingSubscriber::force_synchronize` once we're done
  collecting metrics. This stops calls to `refresh` from hanging, and
  actually allows us to print data.
- Rather than expecting specific span group->event group pairs to always
  be present, just iterate over all the histograms that were collected.
  That way, we don't panic if no `ray_none` or `ray_color` events
  actually occurred.
- Have both a `draw` span for the entire `draw` function, _and_
  a `draw_pixel` span for drawing each pixel. This way we can time
  how long it takes from calling `draw` to drawing each pixel, *and*
  how long it took to draw each pixel

I hope I correctly understood what this code was doing --- if not,
I may have put spans in the wrong places. But...you can keep
tweaking the instrumentation as much as you like, now that we
can actually print histograms without dying.

Current output looks like this:
```
warning: `clovers` (bin "clovers") generated 1 warning
    Finished release [optimized] target(s) in 5.05s
     Running `target/release/clovers --input clovers/scenes/scene.json --samples 1`
clovers 🍀    ray tracing in rust 🦀
width:        1024
height:       1024
samples:      1
max depth:    100
approx. rays: 104857600

Elapsed: 00:00:09
Pixels:  ███████████████████░ 1048000/1048576
ETA:     00:00:00

finished render in 9s 873ms 699us 675ns
output saved: renders/1628360794.png

draw -> ray_color:
 | mean: 8.6µs, p50: 8µs, p90: 16µs, p99: 24µs, p999: 57µs, max: 8232µs
 |
 |   25µs | **************************************** | 99.8th %-ile

pixel -> ray_color:
 | mean: 29.8µs, p50: 16µs, p90: 73µs, p99: 172µs, p999: 327µs, max: 8495µs
 |
 |   25µs | *****************************            | 71.4th %-ile
 |   50µs | ******                                   | 85.7th %-ile
 |   75µs | ***                                      | 92.1th %-ile
 |  100µs | **                                       | 95.6th %-ile
```