### PR TITLE
2021 08 09 refactoring

### DIFF
--- a/clovers/src/bvhnode.rs
+++ b/clovers/src/bvhnode.rs
@@ -115,27 +115,16 @@ impl BVHNode {
                 let hit_left = self.left.hit(ray, distance_min, distance_max, rng);
                 let hit_right = self.right.hit(ray, distance_min, distance_max, rng);
 
-                match &hit_left {
-                    Some(left) => {
-                        match &hit_right {
-                            // Both hit
-                            Some(right) => {
-                                if left.distance < right.distance {
-                                    hit_left
-                                } else {
-                                    hit_right
-                                }
-                            }
-                            // Left hit
-                            None => hit_left,
+                match (&hit_left, &hit_right) {
+                    (None, None) => None,
+                    (None, Some(_)) => hit_right,
+                    (Some(_), None) => hit_left,
+                    (Some(left), Some(right)) => {
+                        if left.distance < right.distance {
+                            return hit_left;
                         }
+                        hit_right
                     }
-                    None => match &hit_right {
-                        // Right hit
-                        Some(_right) => hit_right,
-                        // Neither hit
-                        None => None,
-                    },
                 }
             }
         }

--- a/clovers/src/colorize.rs
+++ b/clovers/src/colorize.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     color::Color,
-    pdf::{HitablePDF, MixturePDF},
+    pdf::{HitablePDF, MixturePDF, PDF},
     ray::Ray,
     scenes::Scene,
     Float, EPSILON_SHADOW_ACNE,
@@ -51,8 +51,10 @@ pub fn colorize(ray: &Ray, scene: &Scene, depth: u32, max_depth: u32, rng: Threa
                         }
                         crate::materials::MaterialType::Diffuse => {
                             // Use a probability density function to figure out where to scatter a new ray
-                            let light_ptr =
-                                HitablePDF::new(&scene.priority_objects, hit_record.position);
+                            let light_ptr = PDF::HitablePDF(HitablePDF::new(
+                                &scene.priority_objects,
+                                hit_record.position,
+                            ));
                             let mixture_pdf = MixturePDF::new(light_ptr, scatter_record.pdf_ptr);
 
                             let scattered =

--- a/clovers/src/hitable.rs
+++ b/clovers/src/hitable.rs
@@ -225,9 +225,8 @@ impl HitableList {
         self.0.push(Arc::new(object));
     }
 
-    pub fn into_bvh(self, time_0: Float, time_1: Float, rng: ThreadRng) -> Hitable {
-        let bvh_node = BVHNode::from_list(self.0, time_0, time_1, rng);
-        Hitable::BVHNode(bvh_node)
+    pub fn into_bvh(self, time_0: Float, time_1: Float, rng: ThreadRng) -> BVHNode {
+        BVHNode::from_list(self.0, time_0, time_1, rng)
     }
 
     // TODO: fixme, silly

--- a/clovers/src/lib.rs
+++ b/clovers/src/lib.rs
@@ -62,7 +62,6 @@
 #![deny(missing_docs)]
 // TODO:
 #![allow(clippy::many_single_char_names)] // Lots of places with coordinates etc
-#![allow(clippy::new_ret_no_self)] // Material types return a Material instead of Self for now
 
 // Externals
 use nalgebra::Vector3;

--- a/clovers/src/materials/dielectric.rs
+++ b/clovers/src/materials/dielectric.rs
@@ -1,7 +1,13 @@
 //! A dielectric material. This resembles glass and other transparent and reflective materials.
 
 use super::{reflect, refract, schlick, MaterialType, ScatterRecord};
-use crate::{color::Color, hitable::HitRecord, pdf::ZeroPDF, ray::Ray, Float, Vec3};
+use crate::{
+    color::Color,
+    hitable::HitRecord,
+    pdf::{ZeroPDF, PDF},
+    ray::Ray,
+    Float, Vec3,
+};
 use rand::prelude::*;
 
 use serde::{Deserialize, Serialize};
@@ -61,7 +67,7 @@ impl<'a> Dielectric {
             material_type: MaterialType::Specular,
             specular_ray: Some(specular_ray),
             attenuation: albedo,
-            pdf_ptr: ZeroPDF::new(), //TODO: ugly hack due to nullptr in original tutorial
+            pdf_ptr: PDF::ZeroPDF(ZeroPDF::new()), //TODO: ugly hack due to nullptr in original tutorial
         })
     }
 

--- a/clovers/src/materials/diffuse_light.rs
+++ b/clovers/src/materials/diffuse_light.rs
@@ -22,7 +22,7 @@ impl Default for DiffuseLight {
     /// Creates a new [DiffuseLight] with white light at intensity `100.0`
     fn default() -> Self {
         DiffuseLight {
-            emit: SolidColor::new(Color::new(100.0, 100.0, 100.0)),
+            emit: Texture::SolidColor(SolidColor::new(Color::new(100.0, 100.0, 100.0))),
         }
     }
 }

--- a/clovers/src/materials/isotropic.rs
+++ b/clovers/src/materials/isotropic.rs
@@ -2,7 +2,12 @@
 
 use super::{MaterialType, ScatterRecord};
 use crate::{
-    color::Color, hitable::HitRecord, pdf::CosinePDF, ray::Ray, textures::Texture, Float, PI,
+    color::Color,
+    hitable::HitRecord,
+    pdf::{CosinePDF, PDF},
+    ray::Ray,
+    textures::Texture,
+    Float, PI,
 };
 use rand::prelude::ThreadRng;
 use serde::{Deserialize, Serialize};
@@ -37,7 +42,7 @@ impl<'a> Isotropic {
             material_type: MaterialType::Diffuse,
             specular_ray: None,
             attenuation: albedo,
-            pdf_ptr: CosinePDF::new(hit_record.normal),
+            pdf_ptr: PDF::CosinePDF(CosinePDF::new(hit_record.normal)),
         })
     }
 

--- a/clovers/src/materials/lambertian.rs
+++ b/clovers/src/materials/lambertian.rs
@@ -1,7 +1,13 @@
 //! Lambertian material. This is the default material with a smooth, matte surface.
 
 use super::{MaterialType, ScatterRecord};
-use crate::{hitable::HitRecord, pdf::CosinePDF, ray::Ray, textures::Texture, Float, PI};
+use crate::{
+    hitable::HitRecord,
+    pdf::{CosinePDF, PDF},
+    ray::Ray,
+    textures::Texture,
+    Float, PI,
+};
 use rand::prelude::ThreadRng;
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +32,7 @@ impl<'a> Lambertian {
             attenuation: self
                 .albedo
                 .color(hit_record.u, hit_record.v, hit_record.position),
-            pdf_ptr: CosinePDF::new(hit_record.normal),
+            pdf_ptr: PDF::CosinePDF(CosinePDF::new(hit_record.normal)),
         })
     }
 

--- a/clovers/src/materials/metal.rs
+++ b/clovers/src/materials/metal.rs
@@ -2,7 +2,11 @@
 
 use super::{reflect, MaterialType, ScatterRecord};
 use crate::{
-    hitable::HitRecord, pdf::ZeroPDF, random::random_in_unit_sphere, ray::Ray, textures::Texture,
+    hitable::HitRecord,
+    pdf::{ZeroPDF, PDF},
+    random::random_in_unit_sphere,
+    ray::Ray,
+    textures::Texture,
     Float, Vec3,
 };
 use rand::prelude::ThreadRng;
@@ -34,7 +38,7 @@ impl<'a> Metal {
             // TODO: fix coordinates. Currently metal only works for [SolidColor]
             attenuation: self.albedo.color(0.0, 0.0, hit_record.position),
             material_type: MaterialType::Specular,
-            pdf_ptr: ZeroPDF::new(),
+            pdf_ptr: PDF::ZeroPDF(ZeroPDF::new()),
         })
     }
 

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -50,30 +50,36 @@ pub enum Object {
 impl From<Object> for Hitable {
     fn from(obj: Object) -> Hitable {
         match obj {
-            Object::XZRect(x) => XZRect::new(x.x0, x.x1, x.z0, x.z1, x.k, x.material),
-            Object::XYRect(x) => XYRect::new(x.x0, x.x1, x.y0, x.y1, x.k, x.material),
-            Object::YZRect(x) => YZRect::new(x.y0, x.y1, x.z0, x.z1, x.k, x.material),
-            Object::Sphere(x) => Sphere::new(x.center, x.radius, x.material),
-            Object::Boxy(x) => Boxy::new(x.corner_0, x.corner_1, x.material),
+            Object::XZRect(x) => {
+                Hitable::XZRect(XZRect::new(x.x0, x.x1, x.z0, x.z1, x.k, x.material))
+            }
+            Object::XYRect(x) => {
+                Hitable::XYRect(XYRect::new(x.x0, x.x1, x.y0, x.y1, x.k, x.material))
+            }
+            Object::YZRect(x) => {
+                Hitable::YZRect(YZRect::new(x.y0, x.y1, x.z0, x.z1, x.k, x.material))
+            }
+            Object::Sphere(x) => Hitable::Sphere(Sphere::new(x.center, x.radius, x.material)),
+            Object::Boxy(x) => Hitable::Boxy(Boxy::new(x.corner_0, x.corner_1, x.material)),
             Object::RotateY(x) => {
                 let obj = *x.object;
                 let obj: Hitable = obj.into();
-                RotateY::new(Arc::new(obj), x.angle)
+                Hitable::RotateY(RotateY::new(Arc::new(obj), x.angle))
             }
             Object::Translate(x) => {
                 let obj = *x.object;
                 let obj: Hitable = obj.into();
-                Translate::new(Arc::new(obj), x.offset)
+                Hitable::Translate(Translate::new(Arc::new(obj), x.offset))
             }
             Object::FlipFace(x) => {
                 let obj = *x.object;
                 let obj: Hitable = obj.into();
-                FlipFace::new(obj)
+                Hitable::FlipFace(FlipFace::new(obj))
             }
             Object::ConstantMedium(x) => {
                 let obj = *x.boundary;
                 let obj: Hitable = obj.into();
-                ConstantMedium::new(Arc::new(obj), x.density, x.texture)
+                Hitable::ConstantMedium(ConstantMedium::new(Arc::new(obj), x.density, x.texture))
             }
         }
     }

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -36,35 +36,35 @@ pub struct Boxy {
 
 impl Boxy {
     /// Initializes a new instance of a box, given two opposing [Vec3] corners `corner_0` and `corner_1`, and a [Material] `material`.
-    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Hitable {
+    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Self {
         let mut sides = HitableList::new();
-        sides.add(XYRect::new(
+        sides.add(Hitable::XYRect(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_1.z, material,
-        ));
-        sides.add(XYRect::new(
+        )));
+        sides.add(Hitable::XYRect(XYRect::new(
             corner_0.x, corner_1.x, corner_0.y, corner_1.y, corner_0.z, material,
-        ));
+        )));
 
-        sides.add(XZRect::new(
+        sides.add(Hitable::XZRect(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_1.y, material,
-        ));
-        sides.add(XZRect::new(
+        )));
+        sides.add(Hitable::XZRect(XZRect::new(
             corner_0.x, corner_1.x, corner_0.z, corner_1.z, corner_0.y, material,
-        ));
+        )));
 
-        sides.add(YZRect::new(
+        sides.add(Hitable::YZRect(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_1.x, material,
-        ));
-        sides.add(YZRect::new(
+        )));
+        sides.add(Hitable::YZRect(YZRect::new(
             corner_0.y, corner_1.y, corner_0.z, corner_1.z, corner_0.x, material,
-        ));
+        )));
 
-        Hitable::Boxy(Boxy {
+        Boxy {
             corner_0,
             corner_1,
             sides: Arc::new(sides),
             material,
-        })
+        }
     }
 
     /// The main `hit` function for a [Boxy]. Given a [Ray](crate::ray::Ray), and an interval `distance_min` and `distance_max`, returns either `None` or `Some(HitRecord)` based on whether the ray intersects with the object during that interval.

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -45,12 +45,12 @@ pub struct ConstantMedium {
 
 impl ConstantMedium {
     /// Creates a new [ConstantMedium] with a known size, shape and density.
-    pub fn new(boundary: Arc<Hitable>, density: Float, texture: Texture) -> Hitable {
-        Hitable::ConstantMedium(ConstantMedium {
+    pub fn new(boundary: Arc<Hitable>, density: Float, texture: Texture) -> Self {
+        ConstantMedium {
             boundary,
             phase_function: Material::Isotropic(Isotropic::new(texture)),
             neg_inv_density: -1.0 / density,
-        })
+        }
     }
 
     /// Hit function for the [ConstantMedium] object. Returns a [HitRecord] if hit. TODO: explain the math for the fog

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -29,10 +29,10 @@ impl FlipFace {
     // TODO: possibly deprecate / remove?
 
     /// Creates a new instance of a [FlipFace]
-    pub fn new(object: Hitable) -> Hitable {
-        Hitable::FlipFace(FlipFace {
+    pub fn new(object: Hitable) -> Self {
+        FlipFace {
             object: Arc::new(object),
-        })
+        }
     }
 
     /// Hit function for the [FlipFace] object. Considering this is a utility object that wraps an internal `object`, it returns a [HitRecord] with the `front_face` property flipped, if the given [Ray] hits the object.

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -1,12 +1,6 @@
 //! A moving sphere object.
 
-use crate::{
-    aabb::AABB,
-    hitable::{HitRecord, Hitable},
-    materials::Material,
-    ray::Ray,
-    Float, Vec3, PI,
-};
+use crate::{aabb::AABB, hitable::HitRecord, materials::Material, ray::Ray, Float, Vec3, PI};
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug)]
@@ -29,15 +23,15 @@ impl MovingSphere {
         time_1: Float,
         radius: Float,
         material: Material,
-    ) -> Hitable {
-        Hitable::MovingSphere(MovingSphere {
+    ) -> Self {
+        MovingSphere {
             center_0,
             center_1,
             time_0,
             time_1,
             radius,
             material,
-        })
+        }
     }
 
     /// Returns the interpolated center of the moving sphere at the given time.

--- a/clovers/src/objects/rect.rs
+++ b/clovers/src/objects/rect.rs
@@ -8,11 +8,8 @@
 #![allow(missing_docs)] // TODO: Lots of undocumented things for now
 
 use crate::{
-    aabb::AABB,
-    hitable::{HitRecord, Hitable},
-    materials::Material,
-    ray::Ray,
-    Float, Vec3, EPSILON_RECT_THICKNESS, EPSILON_SHADOW_ACNE,
+    aabb::AABB, hitable::HitRecord, materials::Material, ray::Ray, Float, Vec3,
+    EPSILON_RECT_THICKNESS, EPSILON_SHADOW_ACNE,
 };
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -41,22 +38,15 @@ pub struct XYRect {
 }
 
 impl XYRect {
-    pub fn new(
-        x0: Float,
-        x1: Float,
-        y0: Float,
-        y1: Float,
-        k: Float,
-        material: Material,
-    ) -> Hitable {
-        Hitable::XYRect(XYRect {
+    pub fn new(x0: Float, x1: Float, y0: Float, y1: Float, k: Float, material: Material) -> Self {
+        XYRect {
             x0,
             x1,
             y0,
             y1,
             k,
             material,
-        })
+        }
     }
 
     pub fn hit(
@@ -153,22 +143,15 @@ pub struct XZRect {
 }
 
 impl XZRect {
-    pub fn new(
-        x0: Float,
-        x1: Float,
-        z0: Float,
-        z1: Float,
-        k: Float,
-        material: Material,
-    ) -> Hitable {
-        Hitable::XZRect(XZRect {
+    pub fn new(x0: Float, x1: Float, z0: Float, z1: Float, k: Float, material: Material) -> Self {
+        XZRect {
             x0,
             x1,
             z0,
             z1,
             k,
             material,
-        })
+        }
     }
 
     pub fn hit(
@@ -265,22 +248,15 @@ pub struct YZRect {
 }
 
 impl YZRect {
-    pub fn new(
-        y0: Float,
-        y1: Float,
-        z0: Float,
-        z1: Float,
-        k: Float,
-        material: Material,
-    ) -> Hitable {
-        Hitable::YZRect(YZRect {
+    pub fn new(y0: Float, y1: Float, z0: Float, z1: Float, k: Float, material: Material) -> Self {
+        YZRect {
             y0,
             y1,
             z0,
             z1,
             k,
             material,
-        })
+        }
     }
 
     pub fn hit(

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -32,7 +32,7 @@ pub struct RotateY {
 
 impl RotateY {
     /// Creates a new `RotateY` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `angle` given.
-    pub fn new(object: Arc<Hitable>, angle: Float) -> Hitable {
+    pub fn new(object: Arc<Hitable>, angle: Float) -> Self {
         // TODO: add proper time support
         let time_0: Float = 0.0;
         let time_1: Float = 1.0;
@@ -43,12 +43,12 @@ impl RotateY {
 
         match bounding_box {
             // No bounding box for object
-            None => Hitable::RotateY(RotateY {
+            None => RotateY {
                 object,
                 sin_theta,
                 cos_theta,
                 bounding_box: None,
-            }),
+            },
             // Got a bounding box
             Some(bbox) => {
                 let mut min: Vec3 = Vec3::new(Float::INFINITY, Float::INFINITY, Float::INFINITY);
@@ -82,12 +82,12 @@ impl RotateY {
                     }
                 }
 
-                Hitable::RotateY(RotateY {
+                RotateY {
                     object,
                     sin_theta,
                     cos_theta,
                     bounding_box: Some(AABB::new(min, max)),
-                })
+                }
             }
         }
     }

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -1,13 +1,8 @@
 //! A sphere object.
 
 use crate::{
-    aabb::AABB,
-    hitable::{HitRecord, Hitable},
-    materials::Material,
-    onb::ONB,
-    random::random_to_sphere,
-    ray::Ray,
-    Float, Vec3, EPSILON_SHADOW_ACNE, PI,
+    aabb::AABB, hitable::HitRecord, materials::Material, onb::ONB, random::random_to_sphere,
+    ray::Ray, Float, Vec3, EPSILON_SHADOW_ACNE, PI,
 };
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -34,12 +29,12 @@ pub struct Sphere {
 
 impl Sphere {
     /// Creates a new `Sphere` object with the given center, radius and material.
-    pub fn new(center: Vec3, radius: Float, material: Material) -> Hitable {
-        Hitable::Sphere(Sphere {
+    pub fn new(center: Vec3, radius: Float, material: Material) -> Self {
+        Sphere {
             center,
             radius,
             material,
-        })
+        }
     }
 
     /// Returns the U,V surface coordinates of a hitpoint

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -30,8 +30,8 @@ pub struct Translate {
 
 impl Translate {
     /// Creates a new `Translate` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `offset` given.
-    pub fn new(object: Arc<Hitable>, offset: Vec3) -> Hitable {
-        Hitable::Translate(Translate { object, offset })
+    pub fn new(object: Arc<Hitable>, offset: Vec3) -> Self {
+        Translate { object, offset }
     }
 
     /// Hit method for the [Translate] object. Finds the translation-adjusted [HitRecord] for the possible intersection of the [Ray] with the encased [Object].

--- a/clovers/src/pdf.rs
+++ b/clovers/src/pdf.rs
@@ -38,11 +38,11 @@ pub struct CosinePDF {
     uvw: ONB,
 }
 
-impl<'a> CosinePDF {
-    pub fn new(w: Vec3) -> PDF<'a> {
-        PDF::CosinePDF(CosinePDF {
+impl CosinePDF {
+    pub fn new(w: Vec3) -> Self {
+        CosinePDF {
             uvw: ONB::build_from_w(w),
-        })
+        }
     }
 
     pub fn value(&self, direction: Vec3, _time: Float, _rng: ThreadRng) -> Float {
@@ -66,8 +66,8 @@ pub struct HitablePDF<'a> {
 }
 
 impl<'a> HitablePDF<'a> {
-    pub fn new(hitable: &'a Hitable, origin: Vec3) -> PDF {
-        PDF::HitablePDF(HitablePDF { origin, hitable })
+    pub fn new(hitable: &'a Hitable, origin: Vec3) -> Self {
+        HitablePDF { origin, hitable }
     }
 
     pub fn value(&self, direction: Vec3, time: Float, rng: ThreadRng) -> Float {
@@ -87,11 +87,11 @@ pub struct MixturePDF<'a> {
 }
 
 impl<'a> MixturePDF<'a> {
-    pub fn new(pdf1: PDF<'a>, pdf2: PDF<'a>) -> PDF<'a> {
-        PDF::MixturePDF(MixturePDF {
+    pub fn new(pdf1: PDF<'a>, pdf2: PDF<'a>) -> Self {
+        MixturePDF {
             pdf1: Arc::new(pdf1),
             pdf2: Arc::new(pdf2),
-        })
+        }
     }
 
     pub fn value(&self, direction: Vec3, time: Float, rng: ThreadRng) -> Float {
@@ -111,9 +111,9 @@ impl<'a> MixturePDF<'a> {
 #[derive(Debug)]
 pub struct ZeroPDF {}
 
-impl<'a> ZeroPDF {
-    pub fn new() -> PDF<'a> {
-        PDF::ZeroPDF(ZeroPDF {})
+impl ZeroPDF {
+    pub fn new() -> Self {
+        ZeroPDF {}
     }
 
     pub fn value(&self, _direction: Vec3, _time: Float, _rng: ThreadRng) -> Float {
@@ -122,5 +122,11 @@ impl<'a> ZeroPDF {
 
     pub fn generate(&self, _rng: ThreadRng) -> Vec3 {
         Vec3::new(1.0, 0.0, 0.0)
+    }
+}
+
+impl Default for ZeroPDF {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -1,6 +1,7 @@
 //! A collection of objects, camera, and other things necessary to describe the environment you wish to render.
 
 use crate::{
+    bvhnode::BVHNode,
     camera::{Camera, CameraInit},
     color::Color,
     hitable::{Hitable, HitableList},
@@ -31,7 +32,7 @@ use std::io::prelude::*;
 /// A representation of the scene that is being rendered.
 pub struct Scene {
     /// Bounding-volume hierarchy of [Hitable] objects in the scene. This could, as currently written, be any [Hitable] - in practice, we place the root of the [BVHNode](crate::bvhnode::BVHNode) tree here.
-    pub objects: Hitable,
+    pub objects: BVHNode,
     /// The camera object used for rendering the scene.
     pub camera: Camera,
     /// The background color to use when the rays do not hit anything in the scene.

--- a/clovers/src/textures/checkered.rs
+++ b/clovers/src/textures/checkered.rs
@@ -1,6 +1,5 @@
 //! Various checkered textures: spatial and surface variants.
 
-use super::Texture;
 use crate::{color::Color, Float, Vec3, PI};
 use serde::{Deserialize, Serialize};
 
@@ -38,12 +37,12 @@ fn default_density_surface() -> Float {
 
 impl SpatialChecker {
     /// Create a new SpatialChecker object with the specified colors and density.
-    pub fn new(color1: Color, color2: Color, density: Float) -> Texture {
-        Texture::SpatialChecker(SpatialChecker {
+    pub fn new(color1: Color, color2: Color, density: Float) -> Self {
+        SpatialChecker {
             even: color1,
             odd: color2,
             density,
-        })
+        }
     }
 
     /// Evaluates the color at the given spatial position coordinate. Note that the SpatialChecker is spatial - surface coordinates are ignored.
@@ -76,12 +75,12 @@ pub struct SurfaceChecker {
 
 impl SurfaceChecker {
     /// Create a new SurfaceChecker object with the specified colors and density.
-    pub fn new(color1: Color, color2: Color, density: Float) -> Texture {
-        Texture::SurfaceChecker(SurfaceChecker {
+    pub fn new(color1: Color, color2: Color, density: Float) -> Self {
+        SurfaceChecker {
             even: color1,
             odd: color2,
             density,
-        })
+        }
     }
 
     /// Evaluates the color at the given surface position coordinates. Note that SurfaceChecker is surface-based, and thus ignores the spatial position coordinate.

--- a/clovers/src/textures/noise_texture.rs
+++ b/clovers/src/textures/noise_texture.rs
@@ -1,6 +1,5 @@
 //! A noise texture utility.
 
-use super::Texture;
 use crate::{color::Color, perlin::Perlin, Float, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -16,8 +15,8 @@ pub struct NoiseTexture {
 
 impl NoiseTexture {
     /// Creates a new NoiseTexture object with the specified Perlin noise and scaling factor.
-    pub fn new(noise: Perlin, scale: Float) -> Texture {
-        Texture::NoiseTexture(NoiseTexture { noise, scale })
+    pub fn new(noise: Perlin, scale: Float) -> Self {
+        NoiseTexture { noise, scale }
     }
 
     // TODO: investigate why this does not swirl as well as the example marble in tutorial

--- a/clovers/src/textures/solid_color.rs
+++ b/clovers/src/textures/solid_color.rs
@@ -1,6 +1,5 @@
 //! A solid color texture.
 
-use super::Texture;
 use crate::{color::Color, Float, Vec3};
 use serde::{Deserialize, Serialize};
 
@@ -13,8 +12,8 @@ pub struct SolidColor {
 
 impl SolidColor {
     /// Creates a new solid color texture with the specified color.
-    pub fn new(color: Color) -> Texture {
-        Texture::SolidColor(SolidColor { color })
+    pub fn new(color: Color) -> Self {
+        SolidColor { color }
     }
 
     /// Evaluates the color ignoring the given surface coordinates and spatial position - always returns the solid color.


### PR DESCRIPTION
- Clippy fixes: `new_ret_no_self`
- `match` statement improvement in `BVHNode`
- explicitly use `BVHNode` in `Scene` instead of `Hitable::BVHNode`