### PR TITLE
2021-08-28 Refactoring part 2

### DIFF
--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -12,7 +12,7 @@ clovers = { path = "../clovers" }
 # Required for everything
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.118", features = ["derive", "rc"] }
+serde = { version = "1.0.127", features = ["derive"], default-features = false }
 serde_json = "1.0.60"
 indicatif = { version = "0.16.0", features = ["rayon"] }
 clap = { version = "3.0.0-beta.2" }

--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 # clovers itself
-clovers = { path = "../clovers" }
+clovers = { path = "../clovers", features = ["serde"]}
 # Required for everything
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }

--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -12,7 +12,7 @@ clovers = { path = "../clovers" }
 # Required for everything
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.127", features = ["derive"], default-features = false }
+serde = { version = "1.0.129", features = ["derive"], default-features = false }
 serde_json = "1.0.60"
 indicatif = { version = "0.16.0", features = ["rayon"] }
 clap = { version = "3.0.0-beta.2" }

--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 # clovers itself
-clovers = { path = "../clovers", features = ["serde"]}
+clovers = { path = "../clovers", features = ["serde-derive"]}
 # Required for everything
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }

--- a/clovers-app/src/draw_gui.rs
+++ b/clovers-app/src/draw_gui.rs
@@ -136,7 +136,7 @@ impl World {
                 let x = (i % width) as i16;
                 let y = height as i16 - (i / width) as i16; // flip y-axis
 
-                let mut rng = SmallRng::from_entropy();
+                let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
                 let mut color: Color = Color::new(0.0, 0.0, 0.0);
 
                 let u = (x as Float + rng.gen::<Float>()) / width as Float;

--- a/clovers-app/src/draw_gui.rs
+++ b/clovers-app/src/draw_gui.rs
@@ -1,4 +1,4 @@
-use crate::{color::Color, colorize::colorize, scenes::Scene, Float, RANDOM_SEED};
+use crate::{color::Color, colorize::colorize, scenes::Scene, Float};
 
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::rngs::SmallRng;

--- a/clovers-app/src/draw_gui.rs
+++ b/clovers-app/src/draw_gui.rs
@@ -1,4 +1,4 @@
-use crate::{color::Color, colorize::colorize, scenes::Scene, Float};
+use crate::{color::Color, colorize::colorize, scenes::Scene, Float, RANDOM_SEED};
 
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::rngs::SmallRng;

--- a/clovers-app/src/draw_gui.rs
+++ b/clovers-app/src/draw_gui.rs
@@ -136,7 +136,7 @@ impl World {
                 let x = (i % width) as i16;
                 let y = height as i16 - (i / width) as i16; // flip y-axis
 
-                let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
+                let mut rng = SmallRng::from_entropy();
                 let mut color: Color = Color::new(0.0, 0.0, 0.0);
 
                 let u = (x as Float + rng.gen::<Float>()) / width as Float;

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Internal
-clovers = { path = "../clovers" }
+clovers = { path = "../clovers", features = ["serde"]}
 # External
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -14,7 +14,7 @@ clovers = { path = "../clovers" }
 # External
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.118", features = ["derive", "rc"] }
+serde = { version = "1.0.127", features = ["derive"], default-features = false }
 serde_json = "1.0.60"
 image = { version = "0.23.12" }
 chrono = { version = "0.4.19" }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Internal
-clovers = { path = "../clovers", features = ["serde"]}
+clovers = { path = "../clovers", features = ["serde-derive"]}
 # External
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -14,7 +14,7 @@ clovers = { path = "../clovers" }
 # External
 rayon = "1.5.0"
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.127", features = ["derive"], default-features = false }
+serde = { version = "1.0.129", features = ["derive"], default-features = false }
 serde_json = "1.0.60"
 image = { version = "0.23.12" }
 chrono = { version = "0.4.19" }

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -1,4 +1,4 @@
-use crate::{color::Color, colorize::colorize, ray::Ray, scenes, Float};
+use crate::{color::Color, colorize::colorize, ray::Ray, scenes, Float, RANDOM_SEED};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -46,7 +46,7 @@ pub fn draw(
             let height = height as Float;
 
             // Initialize a thread-local random number generator
-            let mut rng = SmallRng::from_entropy();
+            let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
 
             // Initialize a mutable base color for the pixel
             let mut color: Color = Color::new(0.0, 0.0, 0.0);

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -1,4 +1,4 @@
-use crate::{color::Color, colorize::colorize, ray::Ray, scenes, Float, RANDOM_SEED};
+use crate::{color::Color, colorize::colorize, ray::Ray, scenes, Float};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -46,7 +46,7 @@ pub fn draw(
             let height = height as Float;
 
             // Initialize a thread-local random number generator
-            let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
+            let mut rng = SmallRng::from_entropy();
 
             // Initialize a mutable base color for the pixel
             let mut color: Color = Color::new(0.0, 0.0, 0.0);

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -14,6 +14,6 @@ crate-type = ["lib"]
 # Required for everything
 nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm"], default-features = false  }
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.129", features = ["derive"], default-features = false }
+serde = { version = "1.0.129", features = ["derive"], default-features = false, optional = true  }
 
 [dev-dependencies]

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 
 [dependencies]
 # Required for everything
-nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm", "rand"], default-features = false  }
+nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm"], default-features = false  }
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
 serde = { version = "1.0.127", features = ["derive"] }
 

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -10,9 +10,12 @@ name = "clovers"
 path = "src/lib.rs"
 crate-type = ["lib"]
 
+[features]
+serde-derive = ["serde/derive", "nalgebra/serde-serialize"]
+
 [dependencies]
 # Required for everything
-nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm"], default-features = false  }
+nalgebra = { version = "0.29.0", features = ["libm"], default-features = false  }
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
 serde = { version = "1.0.129", features = ["derive"], default-features = false, optional = true  }
 

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -14,6 +14,6 @@ crate-type = ["lib"]
 # Required for everything
 nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm"], default-features = false  }
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.127", features = ["derive"], default-features = false }
+serde = { version = "1.0.129", features = ["derive"], default-features = false }
 
 [dev-dependencies]

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -16,7 +16,7 @@ serde-derive = ["serde/derive", "nalgebra/serde-serialize"]
 [dependencies]
 # Required for everything
 nalgebra = { version = "0.29.0", features = ["libm"], default-features = false  }
-rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
+rand = { version = "0.8.4", features = ["small_rng"] }
 serde = { version = "1.0.129", features = ["derive"], default-features = false, optional = true  }
 
 [dev-dependencies]

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -14,6 +14,6 @@ crate-type = ["lib"]
 # Required for everything
 nalgebra = { version = "0.29.0", features = ["serde-serialize", "libm"], default-features = false  }
 rand = { version = "0.8.4", features = ["small_rng"], default-features = false }
-serde = { version = "1.0.127", features = ["derive"] }
+serde = { version = "1.0.127", features = ["derive"], default-features = false }
 
 [dev-dependencies]

--- a/clovers/src/aabb.rs
+++ b/clovers/src/aabb.rs
@@ -1,12 +1,12 @@
 //! Axis-aligned bounding box.
 
 use crate::{ray::Ray, Float, Vec3};
-use serde::{Deserialize, Serialize};
 
 /// Axis-aligned bounding box Defined by two opposing corners, each of which are a [Vec3].
 ///
 /// This is useful for creating bounding volume hierarchies, which is an optimization for reducing the time spent on calculating ray-object intersections.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AABB {
     /// First corner of the axis-aligned bounding box.
     pub min: Vec3,

--- a/clovers/src/aabb.rs
+++ b/clovers/src/aabb.rs
@@ -6,7 +6,7 @@ use crate::{ray::Ray, Float, Vec3};
 ///
 /// This is useful for creating bounding volume hierarchies, which is an optimization for reducing the time spent on calculating ray-object intersections.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct AABB {
     /// First corner of the axis-aligned bounding box.
     pub min: Vec3,

--- a/clovers/src/bvhnode.rs
+++ b/clovers/src/bvhnode.rs
@@ -3,7 +3,7 @@
 use core::cmp::Ordering;
 
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 use crate::{
     aabb::AABB,

--- a/clovers/src/camera.rs
+++ b/clovers/src/camera.rs
@@ -5,9 +5,9 @@
 use crate::{random::random_in_unit_disk, ray::Ray, Float, Vec3, PI};
 use rand::rngs::SmallRng;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The main [Camera] object used in the ray tracing.
 pub struct Camera {
     /// Coordinate of the lower left corner of the camera.
@@ -33,7 +33,8 @@ pub struct Camera {
     pub w: Vec3,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Represents the fields that can be described in a Scene file. Some other fields the main Camera struct requires (such as aspect_ratio) are derived from other info (such as width, height)
 pub struct CameraInit {
     /// Describes where the camera is

--- a/clovers/src/camera.rs
+++ b/clovers/src/camera.rs
@@ -4,7 +4,7 @@
 
 use crate::{random::random_in_unit_disk, ray::Ray, Float, Vec3, PI};
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/clovers/src/camera.rs
+++ b/clovers/src/camera.rs
@@ -7,7 +7,7 @@ use rand::rngs::SmallRng;
 use rand::Rng;
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// The main [Camera] object used in the ray tracing.
 pub struct Camera {
     /// Coordinate of the lower left corner of the camera.
@@ -34,7 +34,7 @@ pub struct Camera {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Represents the fields that can be described in a Scene file. Some other fields the main Camera struct requires (such as aspect_ratio) are derived from other info (such as width, height)
 pub struct CameraInit {
     /// Describes where the camera is

--- a/clovers/src/color.rs
+++ b/clovers/src/color.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 /// RGB color based on three [Floats](crate::Float) values.
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// The red component of the color, as a [Float]
     pub r: Float,

--- a/clovers/src/color.rs
+++ b/clovers/src/color.rs
@@ -6,10 +6,10 @@ use crate::{Float, Vec3};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign};
 use rand::rngs::SmallRng;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
 
 /// RGB color based on three [Floats](crate::Float) values.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     /// The red component of the color, as a [Float]
     pub r: Float,

--- a/clovers/src/color.rs
+++ b/clovers/src/color.rs
@@ -5,7 +5,7 @@
 use crate::{Float, Vec3};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign};
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 /// RGB color based on three [Floats](crate::Float) values.

--- a/clovers/src/colorize.rs
+++ b/clovers/src/colorize.rs
@@ -9,7 +9,6 @@ use crate::{
     Float, EPSILON_SHADOW_ACNE,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 
 /// The main coloring function. Sends a [Ray] to the [Scene], sees if it hits anything, and eventually returns a [Color]. Taking into account the [Material](crate::materials::Material) that is hit, the method recurses with various adjustments, with a new [Ray] started from the location that was hit.
 pub fn colorize(ray: &Ray, scene: &Scene, depth: u32, max_depth: u32, rng: &mut SmallRng) -> Color {

--- a/clovers/src/hitable.rs
+++ b/clovers/src/hitable.rs
@@ -14,7 +14,7 @@ use crate::{
     Float, Vec, Vec3,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 /// Represents a ray-object intersection, with plenty of data about the intersection.
 #[derive(Debug)]

--- a/clovers/src/lib.rs
+++ b/clovers/src/lib.rs
@@ -103,3 +103,5 @@ pub const EPSILON_SHADOW_ACNE: Float = 0.001;
 pub const EPSILON_RECT_THICKNESS: Float = 0.0001;
 /// Internal const: epsilon used in the hit calculation of a [ConstantMedium](objects::constant_medium::ConstantMedium)
 pub const EPSILON_CONSTANT_MEDIUM: Float = 0.0001;
+/// Internal const: random seed used for no_std compatible [SmallRng](rand::rngs::SmallRng). Value is a hex representation of string "odd biases? bad seed", borrowed from [rand docs](https://docs.rs/rand/0.8.4/rand/trait.SeedableRng.html#method.seed_from_u64)
+pub const RANDOM_SEED: u64 = 0x0DDB1A5E5BAD5EEDu64;

--- a/clovers/src/lib.rs
+++ b/clovers/src/lib.rs
@@ -103,5 +103,3 @@ pub const EPSILON_SHADOW_ACNE: Float = 0.001;
 pub const EPSILON_RECT_THICKNESS: Float = 0.0001;
 /// Internal const: epsilon used in the hit calculation of a [ConstantMedium](objects::constant_medium::ConstantMedium)
 pub const EPSILON_CONSTANT_MEDIUM: Float = 0.0001;
-/// Internal const: random seed used for no_std compatible [SmallRng](rand::rngs::SmallRng). Value is a hex representation of string "odd biases? bad seed", borrowed from [rand docs](https://docs.rs/rand/0.8.4/rand/trait.SeedableRng.html#method.seed_from_u64)
-pub const RANDOM_SEED: u64 = 0x0DDB1A5E5BAD5EEDu64;

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -13,9 +13,9 @@ pub use isotropic::*;
 pub use lambertian::*;
 pub use metal::*;
 use rand::prelude::SmallRng;
-use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A material enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 pub enum Material {
     /// Dielectric material

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -15,7 +15,7 @@ pub use metal::*;
 use rand::prelude::SmallRng;
 
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A material enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 pub enum Material {
     /// Dielectric material

--- a/clovers/src/materials/dielectric.rs
+++ b/clovers/src/materials/dielectric.rs
@@ -12,14 +12,14 @@ use rand::rngs::SmallRng;
 use rand::Rng;
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A dielectric material. This resembles glass and other transparent and reflective materials.
 pub struct Dielectric {
     /// Refractive index of the material. Used for calculating the new direction of a ray when entering the material at an angle. Follows Snell's law of refraction. Default value: 1.5, based on typical window glass.
-    #[cfg_attr(feature = "serde", serde(default = "default_index"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_index"))]
     pub refractive_index: Float,
     /// Color of the material. Used for colorizing the rays. Default value: [`Color::new(1.0, 1.0, 1.0)`](crate::color::Color), producing a fully transparent, clear glass.
-    #[cfg_attr(feature = "serde", serde(default = "default_color"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_color"))]
     pub color: Color,
 }
 

--- a/clovers/src/materials/dielectric.rs
+++ b/clovers/src/materials/dielectric.rs
@@ -9,7 +9,7 @@ use crate::{
     Float, Vec3,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 use serde::{Deserialize, Serialize};
 

--- a/clovers/src/materials/dielectric.rs
+++ b/clovers/src/materials/dielectric.rs
@@ -11,16 +11,15 @@ use crate::{
 use rand::rngs::SmallRng;
 use rand::Rng;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A dielectric material. This resembles glass and other transparent and reflective materials.
 pub struct Dielectric {
     /// Refractive index of the material. Used for calculating the new direction of a ray when entering the material at an angle. Follows Snell's law of refraction. Default value: 1.5, based on typical window glass.
-    #[serde(default = "default_index")]
+    #[cfg_attr(feature = "serde", serde(default = "default_index"))]
     pub refractive_index: Float,
     /// Color of the material. Used for colorizing the rays. Default value: [`Color::new(1.0, 1.0, 1.0)`](crate::color::Color), producing a fully transparent, clear glass.
-    #[serde(default = "default_color")]
+    #[cfg_attr(feature = "serde", serde(default = "default_color"))]
     pub color: Color,
 }
 

--- a/clovers/src/materials/diffuse_light.rs
+++ b/clovers/src/materials/diffuse_light.rs
@@ -10,10 +10,9 @@ use crate::{
 };
 use rand::prelude::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
 /// A diffuse light material. On this material, rays never scatter - the material always emits a color based on its texture.
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DiffuseLight {
     emit: Texture,
 }

--- a/clovers/src/materials/diffuse_light.rs
+++ b/clovers/src/materials/diffuse_light.rs
@@ -12,7 +12,7 @@ use rand::prelude::SmallRng;
 
 /// A diffuse light material. On this material, rays never scatter - the material always emits a color based on its texture.
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct DiffuseLight {
     emit: Texture,
 }

--- a/clovers/src/materials/isotropic.rs
+++ b/clovers/src/materials/isotropic.rs
@@ -12,10 +12,10 @@ use crate::{
 use rand::prelude::SmallRng;
 
 #[derive(Debug, Copy, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Isotropic material. Used in [ConstantMedium](crate::objects::constant_medium). TODO: understand this!
 pub struct Isotropic {
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     albedo: Texture,
 }
 

--- a/clovers/src/materials/isotropic.rs
+++ b/clovers/src/materials/isotropic.rs
@@ -10,12 +10,12 @@ use crate::{
     Float, PI,
 };
 use rand::prelude::SmallRng;
-use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Isotropic material. Used in [ConstantMedium](crate::objects::constant_medium). TODO: understand this!
 pub struct Isotropic {
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     albedo: Texture,
 }
 

--- a/clovers/src/materials/lambertian.rs
+++ b/clovers/src/materials/lambertian.rs
@@ -9,12 +9,12 @@ use crate::{
     Float, PI,
 };
 use rand::prelude::SmallRng;
-use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Deserialize, Serialize, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Lambertian material. This is the default material with a smooth, matte surface.
 pub struct Lambertian {
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     albedo: Texture,
 }
 

--- a/clovers/src/materials/lambertian.rs
+++ b/clovers/src/materials/lambertian.rs
@@ -11,10 +11,10 @@ use crate::{
 use rand::prelude::SmallRng;
 
 #[derive(Copy, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Lambertian material. This is the default material with a smooth, matte surface.
 pub struct Lambertian {
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     albedo: Texture,
 }
 

--- a/clovers/src/materials/metal.rs
+++ b/clovers/src/materials/metal.rs
@@ -12,12 +12,12 @@ use crate::{
 use rand::prelude::SmallRng;
 
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A metal material. The amount of reflection can be adjusted with the `fuzz` parameter.
 pub struct Metal {
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     albedo: Texture,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     fuzz: Float,
 }
 

--- a/clovers/src/materials/metal.rs
+++ b/clovers/src/materials/metal.rs
@@ -10,13 +10,14 @@ use crate::{
     Float, Vec3,
 };
 use rand::prelude::SmallRng;
-use serde::{Deserialize, Serialize};
-#[derive(Deserialize, Serialize, Debug, Copy, Clone)]
+
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A metal material. The amount of reflection can be adjusted with the `fuzz` parameter.
 pub struct Metal {
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     albedo: Texture,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     fuzz: Float,
 }
 

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -24,7 +24,7 @@ pub use translate::*;
 
 #[derive(Debug)]
 /// An object enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub enum Object {
     /// XZRect object initializer
     XZRect(XZRectInit),

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -1,7 +1,6 @@
 //! Various literal objects and meta-object utilities for creating content in [Scenes](crate::scenes::Scene).
 
 use crate::{hitable::Hitable, Box};
-use serde::{Deserialize, Serialize};
 
 pub mod boxy; // avoid keyword
 pub mod constant_medium;
@@ -23,8 +22,9 @@ pub use translate::*;
 
 // TODO: This is kind of an ugly hack, having to double-implement various structures to have an external representation vs internal representation. How could this be made cleaner?
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug)]
 /// An object enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Object {
     /// XZRect object initializer
     XZRect(XZRectInit),

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -12,13 +12,13 @@ use rand::rngs::SmallRng;
 
 /// BoxyInit structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoxyInit {
     /// First corner for the box
     pub corner_0: Vec3,
     /// Second, opposing corner for the box
     pub corner_1: Vec3,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material used for the box
     pub material: Material,
 }

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -10,16 +10,15 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
 /// BoxyInit structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoxyInit {
     /// First corner for the box
     pub corner_0: Vec3,
     /// Second, opposing corner for the box
     pub corner_1: Vec3,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Material used for the box
     pub material: Material,
 }

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -9,7 +9,7 @@ use crate::{
     Box, Float, Vec3,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 /// BoxyInit structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -9,7 +9,7 @@ use crate::{
     Box, Float, Vec3, EPSILON_CONSTANT_MEDIUM,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use super::Object;

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -10,23 +10,24 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
 
 use super::Object;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// ConstantMediumInit structure describes the necessary data for constructing a [ConstantMedium]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct ConstantMediumInit {
     /// The boundary object for the constant medium. This determines the size and shape of the fog object.
     pub boundary: Box<Object>,
-    #[serde(default = "default_density")]
+    #[cfg_attr(feature = "serde", serde(default = "default_density"))]
     /// Density of the fog. TODO: example good value range?
     pub density: Float,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     /// [Texture] used for the colorization of the fog.
     pub texture: Texture,
 }
 
+#[cfg(feature = "serde")]
 // TODO: does this density setting even work?
 fn default_density() -> Float {
     0.1

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -14,20 +14,20 @@ use rand::Rng;
 use super::Object;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// ConstantMediumInit structure describes the necessary data for constructing a [ConstantMedium]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct ConstantMediumInit {
     /// The boundary object for the constant medium. This determines the size and shape of the fog object.
     pub boundary: Box<Object>,
-    #[cfg_attr(feature = "serde", serde(default = "default_density"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_density"))]
     /// Density of the fog. TODO: example good value range?
     pub density: Float,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     /// [Texture] used for the colorization of the fog.
     pub texture: Texture,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-derive")]
 // TODO: does this density setting even work?
 fn default_density() -> Float {
     0.1

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -11,7 +11,7 @@ use rand::rngs::SmallRng;
 use super::Object;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// FlipFaceInit structure describes the necessary data for constructing a [FlipFace]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct FlipFaceInit {
     /// The object to wrap with the face flipping feature.

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -8,11 +8,10 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
 use super::Object;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// FlipFaceInit structure describes the necessary data for constructing a [FlipFace]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct FlipFaceInit {
     /// The object to wrap with the face flipping feature.

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -7,7 +7,7 @@ use crate::{
     Box, Float,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 use super::Object;

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -2,7 +2,7 @@
 
 use crate::{aabb::AABB, hitable::HitRecord, materials::Material, ray::Ray, Float, Vec3, PI};
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -4,7 +4,7 @@ use crate::{aabb::AABB, hitable::HitRecord, materials::Material, ray::Ray, Float
 use rand::rngs::SmallRng;
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
 pub struct MovingSphere {
     center_0: Vec3,

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -3,9 +3,8 @@
 use crate::{aabb::AABB, hitable::HitRecord, materials::Material, ray::Ray, Float, Vec3, PI};
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
 pub struct MovingSphere {
     center_0: Vec3,

--- a/clovers/src/objects/rect.rs
+++ b/clovers/src/objects/rect.rs
@@ -12,7 +12,7 @@ use crate::{
     EPSILON_RECT_THICKNESS, EPSILON_SHADOW_ACNE,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 // XY

--- a/clovers/src/objects/rect.rs
+++ b/clovers/src/objects/rect.rs
@@ -17,19 +17,19 @@ use rand::Rng;
 // XY
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct XYRectInit {
     pub x0: Float,
     pub x1: Float,
     pub y0: Float,
     pub y1: Float,
     pub k: Float,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     pub material: Material,
 }
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct XYRect {
     x0: Float,
     x1: Float,
@@ -124,19 +124,19 @@ impl XYRect {
 // XZ
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct XZRectInit {
     pub x0: Float,
     pub x1: Float,
     pub z0: Float,
     pub z1: Float,
     pub k: Float,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     pub material: Material,
 }
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct XZRect {
     x0: Float,
     x1: Float,
@@ -231,19 +231,19 @@ impl XZRect {
 // YZ
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct YZRectInit {
     pub y0: Float,
     pub y1: Float,
     pub z0: Float,
     pub z1: Float,
     pub k: Float,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     pub material: Material,
 }
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct YZRect {
     y0: Float,
     y1: Float,

--- a/clovers/src/objects/rect.rs
+++ b/clovers/src/objects/rect.rs
@@ -13,22 +13,23 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
 
 // XY
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XYRectInit {
     pub x0: Float,
     pub x1: Float,
     pub y0: Float,
     pub y1: Float,
     pub k: Float,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub material: Material,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XYRect {
     x0: Float,
     x1: Float,
@@ -122,18 +123,20 @@ impl XYRect {
 
 // XZ
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XZRectInit {
     pub x0: Float,
     pub x1: Float,
     pub z0: Float,
     pub z1: Float,
     pub k: Float,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub material: Material,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XZRect {
     x0: Float,
     x1: Float,
@@ -227,18 +230,20 @@ impl XZRect {
 
 // YZ
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct YZRectInit {
     pub y0: Float,
     pub y1: Float,
     pub z0: Float,
     pub z1: Float,
     pub k: Float,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub material: Material,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct YZRect {
     y0: Float,
     y1: Float,

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -11,7 +11,7 @@ use rand::rngs::SmallRng;
 use super::Object;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// RotateInit structure describes the necessary data for constructing a [RotateY]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct RotateInit {
     /// The encased [Object] to rotate

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -7,7 +7,7 @@ use crate::{
     Box, Float, Vec3,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 use super::Object;

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -8,11 +8,10 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
 use super::Object;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// RotateInit structure describes the necessary data for constructing a [RotateY]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct RotateInit {
     /// The encased [Object] to rotate

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -5,7 +5,7 @@ use crate::{
     ray::Ray, Float, Vec3, EPSILON_SHADOW_ACNE, PI,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -6,21 +6,21 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// SphereInit structure describes the necessary data for constructing a [Sphere]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct SphereInit {
     /// Center of the sphere.
     pub center: Vec3,
     /// Radius of the sphere.
     pub radius: Float,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     /// Material of the sphere.
     pub material: Material,
 }
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A sphere object.
 pub struct Sphere {
     center: Vec3,

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -7,20 +7,20 @@ use crate::{
 use rand::rngs::SmallRng;
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// SphereInit structure describes the necessary data for constructing a [Sphere]. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct SphereInit {
     /// Center of the sphere.
     pub center: Vec3,
     /// Radius of the sphere.
     pub radius: Float,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material of the sphere.
     pub material: Material,
 }
 
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A sphere object.
 pub struct Sphere {
     center: Vec3,

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -8,11 +8,10 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-use serde::{Deserialize, Serialize};
-
 use super::Object;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// TranslateInit structure describes the necessary data for constructing a [Translate] object. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct TranslateInit {
     /// The encased [Object] to translate i.e. move

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -11,7 +11,7 @@ use rand::rngs::SmallRng;
 use super::Object;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// TranslateInit structure describes the necessary data for constructing a [Translate] object. Used with [serde] when importing [SceneFiles](crate::scenes::SceneFile).
 pub struct TranslateInit {
     /// The encased [Object] to translate i.e. move

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -7,7 +7,7 @@ use crate::{
     Box, Float, Vec3,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+
 use serde::{Deserialize, Serialize};
 
 use super::Object;

--- a/clovers/src/pdf.rs
+++ b/clovers/src/pdf.rs
@@ -4,7 +4,7 @@
 
 use crate::{hitable::Hitable, onb::ONB, random::random_cosine_direction, Box, Float, Vec3, PI};
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 #[derive(Debug)]
 pub enum PDF<'a> {

--- a/clovers/src/perlin.rs
+++ b/clovers/src/perlin.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_range_loop)] // TODO: figure out what clippy wants here
 #![allow(missing_docs)] // TODO: Lots of undocumented things for now
 
-use crate::{Float, Vec3, RANDOM_SEED};
+use crate::{Float, Vec3};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -79,7 +79,7 @@ impl Perlin {
         let mut random_vectors: [Vec3; 256] = [Vec3::new(0.0, 0.0, 0.0); 256];
         for i in 0..256 {
             random_vectors[i] =
-                Vec3::new(rng.gen::<Float>(), rng.gen::<Float>(), rng.gen::<Float>())
+                Vec3::new(rng.gen::<Float>(), rng.gen::<Float>(), rng.gen::<Float>());
         }
 
         let perm_x = perlin_generate_perm(rng);
@@ -147,7 +147,7 @@ impl Perlin {
 
 impl Default for Perlin {
     fn default() -> Self {
-        let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
+        let mut rng = SmallRng::from_entropy();
         Perlin::new(&mut rng)
     }
 }

--- a/clovers/src/perlin.rs
+++ b/clovers/src/perlin.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_range_loop)] // TODO: figure out what clippy wants here
 #![allow(missing_docs)] // TODO: Lots of undocumented things for now
 
-use crate::{Float, Vec3};
+use crate::{Float, Vec3, RANDOM_SEED};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -78,7 +78,8 @@ impl Perlin {
     pub fn new(rng: &mut SmallRng) -> Self {
         let mut random_vectors: [Vec3; 256] = [Vec3::new(0.0, 0.0, 0.0); 256];
         for i in 0..256 {
-            random_vectors[i] = Vec3::new_random();
+            random_vectors[i] =
+                Vec3::new(rng.gen::<Float>(), rng.gen::<Float>(), rng.gen::<Float>())
         }
 
         let perm_x = perlin_generate_perm(rng);
@@ -146,7 +147,7 @@ impl Perlin {
 
 impl Default for Perlin {
     fn default() -> Self {
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
         Perlin::new(&mut rng)
     }
 }

--- a/clovers/src/random.rs
+++ b/clovers/src/random.rs
@@ -2,7 +2,7 @@
 
 use crate::{Float, Vec3, PI};
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
 
 /// Internal helper. Originally used for lambertian reflection with flaws
 pub fn random_in_unit_sphere(rng: &mut SmallRng) -> Vec3 {

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -9,7 +9,7 @@ use crate::{
     Float, Vec,
 };
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 
 // TODO: convert these to json or other

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -6,7 +6,7 @@ use crate::{
     color::Color,
     hitable::{Hitable, HitableList},
     objects::Object,
-    Float, Vec, RANDOM_SEED,
+    Float, Vec,
 };
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
@@ -76,7 +76,7 @@ pub struct SceneFile {
 pub fn initialize(scene_file: SceneFile, width: u32, height: u32) -> Scene {
     let time_0 = scene_file.time_0;
     let time_1 = scene_file.time_1;
-    let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
+    let mut rng = SmallRng::from_entropy();
     let background_color = scene_file.background_color;
     let camera = Camera::new(
         scene_file.camera.look_from,

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
-use serde::{Deserialize, Serialize};
 
 // TODO: convert these to json or other
 // pub mod cornell;
@@ -61,7 +60,8 @@ impl Scene {
 }
 
 // TODO: better naming
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A serialized representation of a [Scene].
 pub struct SceneFile {
     time_0: Float,

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -6,7 +6,7 @@ use crate::{
     color::Color,
     hitable::{Hitable, HitableList},
     objects::Object,
-    Float, Vec,
+    Float, Vec, RANDOM_SEED,
 };
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
@@ -76,7 +76,7 @@ pub struct SceneFile {
 pub fn initialize(scene_file: SceneFile, width: u32, height: u32) -> Scene {
     let time_0 = scene_file.time_0;
     let time_1 = scene_file.time_1;
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::seed_from_u64(RANDOM_SEED);
     let background_color = scene_file.background_color;
     let camera = Camera::new(
         scene_file.camera.look_from,

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -61,7 +61,7 @@ impl Scene {
 
 // TODO: better naming
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A serialized representation of a [Scene].
 pub struct SceneFile {
     time_0: Float,

--- a/clovers/src/textures.rs
+++ b/clovers/src/textures.rs
@@ -5,7 +5,6 @@
 pub mod checkered;
 pub mod noise_texture;
 pub mod solid_color;
-use serde::{Deserialize, Serialize};
 
 pub use checkered::*;
 // pub use noise_texture::*;
@@ -14,7 +13,8 @@ pub use solid_color::*;
 use crate::{color::Color, Float, Vec3};
 use noise_texture::NoiseTexture;
 
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A texture enum.
 pub enum Texture {
     /// SpatialChecker texture

--- a/clovers/src/textures.rs
+++ b/clovers/src/textures.rs
@@ -14,7 +14,7 @@ use crate::{color::Color, Float, Vec3};
 use noise_texture::NoiseTexture;
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A texture enum.
 pub enum Texture {
     /// SpatialChecker texture

--- a/clovers/src/textures/checkered.rs
+++ b/clovers/src/textures/checkered.rs
@@ -3,38 +3,38 @@
 use crate::{color::Color, Float, Vec3, PI};
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on spatial 3D texturing.
 pub struct SpatialChecker {
-    #[cfg_attr(feature = "serde", serde(default = "default_even"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_even"))]
     /// Uniform color for the even-numbered checkers of the texture.
     pub even: Color,
-    #[cfg_attr(feature = "serde", serde(default = "default_odd"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_odd"))]
     /// Uniform color for the odd-numbered checkers of the texture.
     pub odd: Color,
-    #[cfg_attr(feature = "serde", serde(default = "default_density_spatial"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_density_spatial"))]
     /// Controls the density of the checkered pattern. Default value is 1.0, which corresponds to filling a 1.0 unit cube in the coordinate system with one color of the pattern. Even values preferred - odd values may create a visually thicker stripe due to two stripes with same color being next to each other.
     pub density: Float,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-derive")]
 fn default_even() -> Color {
     // White minus middle gray 18%
     Color::new(0.82, 0.82, 0.82)
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-derive")]
 fn default_odd() -> Color {
     // Middle gray 18%
     Color::new(0.18, 0.18, 0.18)
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-derive")]
 fn default_density_spatial() -> Float {
     1.0
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serde-derive")]
 fn default_density_surface() -> Float {
     10.0
 }
@@ -66,14 +66,14 @@ impl SpatialChecker {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on 2D surface UV coordinates.
 pub struct SurfaceChecker {
-    #[cfg_attr(feature = "serde", serde(default = "default_even"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_even"))]
     even: Color,
-    #[cfg_attr(feature = "serde", serde(default = "default_odd"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_odd"))]
     odd: Color,
-    #[cfg_attr(feature = "serde", serde(default = "default_density_surface"))]
+    #[cfg_attr(feature = "serde-derive", serde(default = "default_density_surface"))]
     /// Controls the density of the checkered pattern. Default value is 10, which corresponds to using 10 tiles over the width of the object. On spheres, this means 10 tiles around the sphere.
     density: Float,
 }

--- a/clovers/src/textures/checkered.rs
+++ b/clovers/src/textures/checkered.rs
@@ -1,36 +1,40 @@
 //! Various checkered textures: spatial and surface variants.
 
 use crate::{color::Color, Float, Vec3, PI};
-use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on spatial 3D texturing.
 pub struct SpatialChecker {
-    #[serde(default = "default_even")]
+    #[cfg_attr(feature = "serde", serde(default = "default_even"))]
     /// Uniform color for the even-numbered checkers of the texture.
     pub even: Color,
-    #[serde(default = "default_odd")]
+    #[cfg_attr(feature = "serde", serde(default = "default_odd"))]
     /// Uniform color for the odd-numbered checkers of the texture.
     pub odd: Color,
-    #[serde(default = "default_density_spatial")]
+    #[cfg_attr(feature = "serde", serde(default = "default_density_spatial"))]
     /// Controls the density of the checkered pattern. Default value is 1.0, which corresponds to filling a 1.0 unit cube in the coordinate system with one color of the pattern. Even values preferred - odd values may create a visually thicker stripe due to two stripes with same color being next to each other.
     pub density: Float,
 }
 
+#[cfg(feature = "serde")]
 fn default_even() -> Color {
     // White minus middle gray 18%
     Color::new(0.82, 0.82, 0.82)
 }
 
+#[cfg(feature = "serde")]
 fn default_odd() -> Color {
     // Middle gray 18%
     Color::new(0.18, 0.18, 0.18)
 }
 
+#[cfg(feature = "serde")]
 fn default_density_spatial() -> Float {
     1.0
 }
 
+#[cfg(feature = "serde")]
 fn default_density_surface() -> Float {
     10.0
 }
@@ -61,14 +65,15 @@ impl SpatialChecker {
     }
 }
 
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on 2D surface UV coordinates.
 pub struct SurfaceChecker {
-    #[serde(default = "default_even")]
+    #[cfg_attr(feature = "serde", serde(default = "default_even"))]
     even: Color,
-    #[serde(default = "default_odd")]
+    #[cfg_attr(feature = "serde", serde(default = "default_odd"))]
     odd: Color,
-    #[serde(default = "default_density_surface")]
+    #[cfg_attr(feature = "serde", serde(default = "default_density_surface"))]
     /// Controls the density of the checkered pattern. Default value is 10, which corresponds to using 10 tiles over the width of the object. On spheres, this means 10 tiles around the sphere.
     density: Float,
 }

--- a/clovers/src/textures/noise_texture.rs
+++ b/clovers/src/textures/noise_texture.rs
@@ -5,10 +5,10 @@ use crate::{color::Color, perlin::Perlin, Float, Vec3};
 // TODO: This might be currently oddly broken and resulting in overflowy surfaces
 // TODO: better documentation
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A NoiseTexture object.
 pub struct NoiseTexture {
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(feature = "serde-derive", serde(skip))]
     noise: Perlin,
     scale: Float,
 }

--- a/clovers/src/textures/noise_texture.rs
+++ b/clovers/src/textures/noise_texture.rs
@@ -1,14 +1,14 @@
 //! A noise texture utility.
 
 use crate::{color::Color, perlin::Perlin, Float, Vec3};
-use serde::{Deserialize, Serialize};
 
 // TODO: This might be currently oddly broken and resulting in overflowy surfaces
 // TODO: better documentation
-#[derive(Copy, Clone, Deserialize, Serialize, Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A NoiseTexture object.
 pub struct NoiseTexture {
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     noise: Perlin,
     scale: Float,
 }

--- a/clovers/src/textures/solid_color.rs
+++ b/clovers/src/textures/solid_color.rs
@@ -1,9 +1,9 @@
 //! A solid color texture.
 
 use crate::{color::Color, Float, Vec3};
-use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Deserialize, Serialize, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A solid color texture. Simplest possible [Texture](crate::textures::Texture): returns a solid color at any surface coordinate or spatial position.
 pub struct SolidColor {
     /// The color of the [Texture](crate::textures::Texture).

--- a/clovers/src/textures/solid_color.rs
+++ b/clovers/src/textures/solid_color.rs
@@ -3,7 +3,7 @@
 use crate::{color::Color, Float, Vec3};
 
 #[derive(Copy, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A solid color texture. Simplest possible [Texture](crate::textures::Texture): returns a solid color at any surface coordinate or spatial position.
 pub struct SolidColor {
     /// The color of the [Texture](crate::textures::Texture).


### PR DESCRIPTION
- `cargo fix` and `cargo fmt` to fix some unused import warnings
- ~use `seed_from_u64` instead of `from_entropy` for `no_std` compatibility. might need to be~ reverted due to artefacts
- add a `serde-derive` feature gate for `clovers` library & tighten up `serde` dependencies