### PR TITLE
2021-09-02 Dependency upgrades

### DIFF
--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = "1.0.60"
 indicatif = { version = "0.16.0", features = ["rayon"] }
 clap = { version = "3.0.0-beta.2" }
 # Required for GUI
-pixels = { version = "0.5.0" }
-winit = { version = "0.24.0" }
-winit_input_helper = { version = "0.9.0" }
+pixels = { version = "0.6.0" }
+winit = { version = "0.25.0" }
+winit_input_helper = { version = "0.10.0" }
 
 [dev-dependencies]

--- a/clovers-app/README.md
+++ b/clovers-app/README.md
@@ -1,3 +1,5 @@
 # clovers 🍀 ray tracing in rust 🦀
 
 This directory contains an example GUI application utilizing `clovers` as the rendering library.
+
+NOTE: this is currently broken and needs a complete rewrite.

--- a/clovers-app/src/draw_gui.rs
+++ b/clovers-app/src/draw_gui.rs
@@ -1,5 +1,6 @@
 use crate::{color::Color, colorize::colorize, scenes::Scene, Float};
 
+use clovers::RenderOpts;
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -16,18 +17,12 @@ use winit::{
 
 use winit_input_helper::WinitInputHelper;
 
-pub fn draw_gui(
-    width: u32,
-    height: u32,
-    samples: u32,
-    max_depth: u32,
-    gamma: Float,
-    scene: Scene,
-) -> Result<(), Error> {
+// TODO: complete rewrite of this function
+pub fn draw_gui(opts: RenderOpts, scene: Scene) -> Result<(), Error> {
     let event_loop = EventLoop::new();
     let mut input = WinitInputHelper::new();
     let window = {
-        let size = PhysicalSize::new(width as f64, height as f64);
+        let size = PhysicalSize::new(opts.width as f64, opts.height as f64);
         WindowBuilder::new()
             .with_title("clovers 🍀 ray tracing in rust 🦀")
             .with_inner_size(size)
@@ -36,11 +31,18 @@ pub fn draw_gui(
             .unwrap()
     };
     let mut pixels = {
-        let surface_texture = SurfaceTexture::new(width, height, &window);
-        Pixels::new(width, height, surface_texture)?
+        let surface_texture = SurfaceTexture::new(opts.width, opts.height, &window);
+        Pixels::new(opts.width, opts.height, surface_texture)?
     };
 
-    let mut world = World::new(width, height, samples, max_depth, gamma, scene);
+    let mut world = World::new(
+        opts.width,
+        opts.height,
+        opts.samples,
+        opts.max_depth,
+        opts.gamma,
+        scene,
+    );
     let mut frame_num = 0;
 
     event_loop.run(move |event, _, control_flow| {

--- a/clovers-app/src/main.rs
+++ b/clovers-app/src/main.rs
@@ -40,6 +40,18 @@ struct Opts {
     /// Gamma correction value
     #[clap(short, long, default_value = "2.0")]
     gamma: Float,
+    /// Suppress most of the text output
+    #[clap(short, long)]
+    quiet: bool,
+    /// Use the GPU draw process instead of CPU
+    // #[clap(long)]
+    // gpu: bool,
+    /// Enable some debug logging
+    // #[clap(long)]
+    // debug: bool,
+    /// Render a normal map only. Experimental feature.
+    #[clap(long)]
+    normalmap: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -62,15 +74,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scene_file: SceneFile = serde_json::from_str(&contents)?;
     let scene: Scene = scenes::initialize(scene_file, opts.width, opts.height);
 
-    // gui version
-    let _result = draw_gui(
-        opts.width,
-        opts.height,
-        opts.samples,
-        opts.max_depth,
-        opts.gamma,
-        scene,
-    );
+    let renderopts: RenderOpts = RenderOpts {
+        width: opts.width,
+        height: opts.height,
+        samples: opts.samples,
+        max_depth: opts.max_depth,
+        gamma: opts.gamma,
+        quiet: opts.quiet,
+        normalmap: opts.normalmap,
+    };
+
+    // TODO: write result to file
+    // TODO: have an actual UI for things
+    let _result = draw_gui(renderopts, scene);
 
     Ok(())
 }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -22,7 +22,7 @@ humantime = { version = "2.0.1" }
 indicatif = { version = "0.16.0", features = ["rayon"] }
 clap = { version = "3.0.0-beta.2" }
 spirv-builder = { git = "https://github.com/EmbarkStudios/rust-gpu" }
-wgpu = "0.9.0"
+wgpu = { version = "0.10.1", features = ["spirv"] }
 bytemuck = {version = "1.7.2", features = ["derive"]}
 futures = "0.3.16"
 env_logger = "0.9.0"

--- a/clovers-cli/README.md
+++ b/clovers-cli/README.md
@@ -1,0 +1,5 @@
+# clovers 🍀 ray tracing in rust 🦀
+
+This directory contains the command-line application for headless ray tracing rendering.
+
+Check the `--help` option for usage instructions.

--- a/clovers-cli/src/draw_gpu.rs
+++ b/clovers-cli/src/draw_gpu.rs
@@ -51,7 +51,7 @@ fn create_pipeline(
             targets: &[wgpu::ColorTargetState {
                 format: swapchain_format,
                 blend: None,
-                write_mask: wgpu::ColorWrite::ALL,
+                write_mask: wgpu::ColorWrites::ALL,
             }],
         }),
     })
@@ -71,7 +71,7 @@ pub struct ShaderConstants {
 /// The main drawing function, returns a Vec<Color> as a pixelbuffer.
 pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
     // Initialize the GPU instance
-    let instance = wgpu::Instance::new(wgpu::BackendBit::VULKAN | wgpu::BackendBit::METAL);
+    let instance = wgpu::Instance::new(wgpu::Backends::VULKAN | wgpu::Backends::METAL);
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::default(),
@@ -102,7 +102,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
         label: None,
         bind_group_layouts: &[],
         push_constant_ranges: &[wgpu::PushConstantRange {
-            stages: wgpu::ShaderStage::all(),
+            stages: wgpu::ShaderStages::all(),
             range: 0..std::mem::size_of::<ShaderConstants>() as u32,
         }],
     });
@@ -138,7 +138,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
         sample_count: 1,
         dimension: wgpu::TextureDimension::D3,
         format: wgpu::TextureFormat::Rgba32Float,
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
     };
     let texture = device.create_texture(&texture_desc);
     debug!("Texture created");
@@ -181,7 +181,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
     rpass.set_pipeline(&render_pipeline);
     debug!("Render pipeline set");
     rpass.set_push_constants(
-        wgpu::ShaderStage::all(),
+        wgpu::ShaderStages::all(),
         0,
         bytemuck::bytes_of(&push_constants),
     );
@@ -198,7 +198,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
     let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: None,
         size: (buffer_dimensions.padded_bytes_per_row * buffer_dimensions.height) as u64,
-        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
 
@@ -211,6 +211,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
             texture: &texture,
             mip_level: 0,
             origin: wgpu::Origin3d::ZERO,
+            aspect: Default::default(),
         },
         wgpu::ImageCopyBuffer {
             buffer: &output_buffer,
@@ -286,7 +287,6 @@ fn load_shader() -> wgpu::ShaderModuleDescriptor<'static> {
     wgpu::ShaderModuleDescriptor {
         label: Some("clovers-shader"),
         source: spirv,
-        flags: Default::default(),
     }
 }
 


### PR DESCRIPTION
- Update `wgpu` from `0.9.0` to `0.10.1`, fixes https://github.com/Walther/clovers/issues/102
- Update `pixels` from `0.5.0` to `0.6.0`
- This temporarily breaks the GUI application `clovers-app` for an unknown reason, but it needs a complete rewrite anyway - https://github.com/Walther/clovers/issues/115