### PR TITLE
2022-04-14 Updates

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-08-27 # rust-toolchain.toml not supported yet https://github.com/actions-rs/toolchain/pull/166
+          toolchain: nightly-2022-04-11 # rust-toolchain.toml not supported yet https://github.com/actions-rs/toolchain/pull/166
           profile: minimal
           components: rustfmt, rust-src
 

--- a/clovers-app/Cargo.toml
+++ b/clovers-app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clovers-app"
 version = "0.1.0"
 authors = ["Walther <veeti.haapsamo@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clovers-cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]
@@ -21,10 +21,9 @@ chrono = "0.4.19"
 humantime = "2.1.0"
 indicatif = { version = "0.16.2", features = ["rayon"] }
 clap = { version = "3.1.8", features = ["derive"] }
-spirv-builder = { git = "https://github.com/EmbarkStudios/rust-gpu", rev = "eeb67ae7489e5df03231f73d108a8f2feae2ca1a" }
+spirv-builder = { git = "https://github.com/EmbarkStudios/rust-gpu", rev = "116bf9c4d413df7413ae931ee31b2777c7abf64e" }
 bytemuck = { version = "1.7.2", features = ["derive"] }
 futures = "0.3.17"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.20"
-# TODO: use a normal version after release of 0.11.0 or so, when web-sys dependency issue has been fixed and released
-wgpu = { git = "https://github.com/gfx-rs/wgpu", features = ["spirv"], rev = "d50e74747d515f7e377f249a2918d3e62a33a57a" }
+wgpu = { version = "0.12.0", features = ["spirv"] }

--- a/clovers-cli/rust-toolchain.toml
+++ b/clovers-cli/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # Required for rust-gpu
 [toolchain]
-channel = "nightly-2021-08-27"
+channel = "nightly-2022-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/clovers-cli/src/draw_gpu.rs
+++ b/clovers-cli/src/draw_gpu.rs
@@ -139,7 +139,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
         size: texture_size,
         mip_level_count: 1,
         sample_count: 1,
-        dimension: wgpu::TextureDimension::D3,
+        dimension: wgpu::TextureDimension::D2,
         format: wgpu::TextureFormat::Rgba32Float,
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
     };
@@ -149,7 +149,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
     let texture_view_desc = TextureViewDescriptor {
         label: None,
         format: Some(wgpu::TextureFormat::Rgba32Float),
-        dimension: Some(wgpu::TextureViewDimension::D3),
+        dimension: Some(wgpu::TextureViewDimension::D2),
         aspect: TextureAspect::All,
         base_mip_level: Default::default(),
         mip_level_count: Default::default(),

--- a/clovers-cli/src/draw_gpu.rs
+++ b/clovers-cli/src/draw_gpu.rs
@@ -35,7 +35,7 @@ fn create_pipeline(
             strip_index_format: None,
             front_face: wgpu::FrontFace::Ccw,
             cull_mode: None,
-            clamp_depth: false,
+            unclipped_depth: false,
             polygon_mode: wgpu::PolygonMode::Fill,
             conservative: false,
         },
@@ -54,6 +54,7 @@ fn create_pipeline(
                 write_mask: wgpu::ColorWrites::ALL,
             }],
         }),
+        multiview: None,
     })
 }
 
@@ -77,6 +78,7 @@ pub async fn draw(opts: RenderOpts, _scene: Scene) -> Vec<Color> {
             power_preference: wgpu::PowerPreference::default(),
             // Do not request a drawing surface; headless mode
             compatible_surface: None,
+            force_fallback_adapter: false,
         })
         .await
         .expect("Failed to find an appropriate adapter");

--- a/clovers-gpu/rust-toolchain.toml
+++ b/clovers-gpu/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # Required for rust-gpu
 [toolchain]
-channel = "nightly-2021-08-27"
+channel = "nightly-2022-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/clovers-gpu/shaders/Cargo.toml
+++ b/clovers-gpu/shaders/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "clovers-shader"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]
 crate-type = ["dylib"]
 
 [dependencies]
-spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu", rev = "eeb67ae7489e5df03231f73d108a8f2feae2ca1a", features = ["glam"] }
+spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu", rev = "116bf9c4d413df7413ae931ee31b2777c7abf64e", features = ["glam"] }

--- a/clovers-gpu/shaders/rust-toolchain.toml
+++ b/clovers-gpu/shaders/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # Required for rust-gpu
 [toolchain]
-channel = "nightly-2021-08-27"
+channel = "nightly-2022-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clovers"
 version = "0.1.0"
 authors = ["Walther <veeti.haapsamo@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -26,8 +26,6 @@ pub struct BoxyInit {
 /// A box or a cuboid object: a parallelepiped with six rectangular faces. Named [Boxy] to avoid clashing with [Box].
 #[derive(Debug, Clone)]
 pub struct Boxy {
-    corner_0: Vec3,
-    corner_1: Vec3,
     sides: Box<HitableList>,
     /// The material of the box
     pub material: Material,
@@ -108,8 +106,6 @@ impl Boxy {
         let aabb = AABB::new_from_coords(corner_0, corner_1);
 
         Boxy {
-            corner_0,
-            corner_1,
             sides: Box::new(sides),
             material,
             aabb,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Required for rust-gpu
 # TODO: would be nice if this wasn't required at root level, only where the gpu is used
 [toolchain]
-channel = "nightly-2021-08-27"
+channel = "nightly-2022-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
- Rust Edition 2021
- Rust nightly version `2022-04-11`
- `rust-gpu` update to new commit hash `116bf9c4d413df7413ae931ee31b2777c7abf64e`