### PR TITLE
2022 10 06 improvements

### DIFF
--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -19,6 +19,7 @@ traces = ["tracing"]
 [dependencies]
 nalgebra = { version = "0.31.1", features = ["libm"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }
+rand_distr = "0.4.3"
 serde = { version = "1.0.145", features = ["derive"], default-features = false, optional = true }
 # TODO: remove git dependency after there's a new release with https://github.com/hmeyer/stl_io/pull/14
 stl_io = { git = "https://github.com/hmeyer/stl_io", rev = "80cce5351ee4f8eb2c5cfa9114f8c2bf961f62fa", optional = true }

--- a/clovers/src/random.rs
+++ b/clovers/src/random.rs
@@ -1,6 +1,7 @@
 //! Various internal helper functions for getting specific kinds of random values.
 
 use crate::{Float, Vec3, PI};
+use rand::distributions::Uniform;
 use rand::rngs::SmallRng;
 use rand::Rng;
 
@@ -9,13 +10,13 @@ use rand::Rng;
 #[inline]
 pub fn random_in_unit_sphere(rng: &mut SmallRng) -> Vec3 {
     let mut position: Vec3;
-    // TODO: figure out a non-loop method
-    // See https://github.com/RayTracing/raytracing.github.io/issues/765
+    let distribution = Uniform::new(-1.0, 1.0);
+
     loop {
         position = Vec3::new(
-            rng.gen_range(-1.0..1.0),
-            rng.gen_range(-1.0..1.0),
-            rng.gen_range(-1.0..1.0),
+            rng.sample(distribution),
+            rng.sample(distribution),
+            rng.sample(distribution),
         );
         if position.magnitude_squared() <= 1.0 {
             return position;
@@ -33,12 +34,12 @@ pub fn random_unit_vector(rng: &mut SmallRng) -> Vec3 {
 #[must_use]
 pub fn random_in_unit_disk(rng: &mut SmallRng) -> Vec3 {
     let mut position: Vec3;
-    // TODO: figure out a non-loop method
-    // See https://github.com/RayTracing/raytracing.github.io/issues/765
+    let distribution = Uniform::new(-1.0, 1.0);
+
     loop {
         position = Vec3::new(
-            rng.gen_range(-1.0..1.0),
-            rng.gen_range(-1.0..1.0),
+            rng.sample(distribution),
+            rng.sample(distribution),
             0.0, // z component zero
         );
         if position.magnitude_squared() <= 1.0 {

--- a/clovers/src/random.rs
+++ b/clovers/src/random.rs
@@ -1,27 +1,15 @@
 //! Various internal helper functions for getting specific kinds of random values.
 
 use crate::{Float, Vec3, PI};
-use rand::distributions::Uniform;
 use rand::rngs::SmallRng;
 use rand::Rng;
+use rand_distr::{Distribution, UnitBall, UnitDisc};
 
 /// Internal helper. Originally used for lambertian reflection with flaws
 #[must_use]
 #[inline]
 pub fn random_in_unit_sphere(rng: &mut SmallRng) -> Vec3 {
-    let mut position: Vec3;
-    let distribution = Uniform::new(-1.0, 1.0);
-
-    loop {
-        position = Vec3::new(
-            rng.sample(distribution),
-            rng.sample(distribution),
-            rng.sample(distribution),
-        );
-        if position.magnitude_squared() <= 1.0 {
-            return position;
-        }
-    }
+    UnitBall.sample(rng).into()
 }
 
 /// Internal helper. Use this for the more correct "True Lambertian" reflection
@@ -33,19 +21,8 @@ pub fn random_unit_vector(rng: &mut SmallRng) -> Vec3 {
 /// Internal helper.
 #[must_use]
 pub fn random_in_unit_disk(rng: &mut SmallRng) -> Vec3 {
-    let mut position: Vec3;
-    let distribution = Uniform::new(-1.0, 1.0);
-
-    loop {
-        position = Vec3::new(
-            rng.sample(distribution),
-            rng.sample(distribution),
-            0.0, // z component zero
-        );
-        if position.magnitude_squared() <= 1.0 {
-            return position;
-        }
-    }
+    let v: [Float; 2] = UnitDisc.sample(rng);
+    Vec3::new(v[0], v[1], 0.0)
 }
 
 /// Internal helper.

--- a/clovers/src/random.rs
+++ b/clovers/src/random.rs
@@ -3,7 +3,7 @@
 use crate::{Float, Vec3, PI};
 use rand::rngs::SmallRng;
 use rand::Rng;
-use rand_distr::{Distribution, UnitBall, UnitDisc};
+use rand_distr::{Distribution, UnitBall, UnitDisc, UnitSphere};
 
 /// Internal helper. Originally used for lambertian reflection with flaws
 #[must_use]
@@ -15,7 +15,7 @@ pub fn random_in_unit_sphere(rng: &mut SmallRng) -> Vec3 {
 /// Internal helper. Use this for the more correct "True Lambertian" reflection
 #[must_use]
 pub fn random_unit_vector(rng: &mut SmallRng) -> Vec3 {
-    random_in_unit_sphere(rng).normalize()
+    UnitSphere.sample(rng).into()
 }
 
 /// Internal helper.


### PR DESCRIPTION
Simpler and faster random number generation by using the `rand_distr` crate.

`random_in_unit_sphere` and `random_unit_vector` improve significantly. for some unknown reason however `random_in_unit_disk` regresses slightly, which is odd.

## Before
```
random in unit sphere   time:   [47.576 ns 47.619 ns 47.659 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

random in unit disk     time:   [18.237 ns 18.247 ns 18.262 ns]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

random unit vector      time:   [49.413 ns 49.492 ns 49.568 ns]
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low severe
  9 (9.00%) low mild
  2 (2.00%) high mild

random cosine direction time:   [18.166 ns 18.176 ns 18.191 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

random in hemisphere    time:   [58.034 ns 58.064 ns 58.093 ns]
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
```
 
 ## After
 ```
 random in unit sphere   time:   [32.538 ns 32.554 ns 32.567 ns]                                                                                                                                 
                        change: [-31.716% -31.655% -31.593%] (p = 0.00 < 0.05)                                                                                                                  
                        Performance has improved.                                                                                                                                               
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe  
  5 (5.00%) high mild
  
random in unit disk     time:   [21.270 ns 21.274 ns 21.279 ns]
                        change: [+16.511% +16.583% +16.652%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild    
  2 (2.00%) high mild   
  1 (1.00%) high severe
  
random unit vector      time:   [28.994 ns 28.999 ns 29.004 ns]
                        change: [-41.460% -41.382% -41.299%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild    
  1 (1.00%) high mild   
  2 (2.00%) high severe
  
random cosine direction time:   [17.833 ns 17.842 ns 17.851 ns]
                        change: [-1.9810% -1.9046% -1.8365%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild    
  2 (2.00%) high mild
  
random in hemisphere    time:   [58.822 ns 59.002 ns 59.383 ns]
                        change: [+1.0610% +1.2792% +1.6223%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
  ```