### PR TITLE
2023-01-08 tiny fixes

### DIFF
--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 clovers = { path = "../clovers", features = ["serde-derive", "stl", "traces", "gl_tf"], default-features = false }
 
 # External
-clap = { version = "4.0.29", features = ["std", "derive"], default-features = false  }
+clap = { version = "4.0.32", features = ["std", "derive"], default-features = false  }
 human_format = "1.0.3"
 humantime = "2.1.0"
 image = { version =  "0.24.5", features = ["png"], default-features = false }
@@ -21,7 +21,7 @@ img-parts = "0.3.0"
 indicatif = { git = "https://github.com/console-rs/indicatif", rev = "2954b1a24ac5f1900a7861992e4825bff643c9e2", features = ["rayon"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng", "getrandom"], default-features = false }
 rayon = "1.6.1"
-serde = { version = "1.0.150", features = ["derive"], default-features = false }
+serde = { version = "1.0.152", features = ["derive"], default-features = false }
 serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 time = { version = "0.3.17", default-features = false }
 tracing = "0.1.37"

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -18,7 +18,7 @@ human_format = "1.0.3"
 humantime = "2.1.0"
 image = { version =  "0.24.5", features = ["png"], default-features = false }
 img-parts = "0.3.0"
-indicatif = { version = "0.17.2", features = ["rayon"], default-features = false }
+indicatif = { git = "https://github.com/console-rs/indicatif", rev = "2954b1a24ac5f1900a7861992e4825bff643c9e2", features = ["rayon"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng", "getrandom"], default-features = false }
 rayon = "1.6.1"
 serde = { version = "1.0.150", features = ["derive"], default-features = false }

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -5,6 +5,7 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
 use scenes::Scene;
+use std::time::Duration;
 
 /// The main drawing function, returns a `Vec<Color>` as a pixelbuffer.
 pub fn draw(opts: RenderOpts, scene: Scene) -> Vec<Color> {
@@ -18,6 +19,7 @@ pub fn draw(opts: RenderOpts, scene: Scene) -> Vec<Color> {
         bar.set_style(ProgressStyle::default_bar().template(
             "Elapsed: {elapsed_precise}\nPixels:  {bar} {pos}/{len}\nETA:     {eta_precise}",
         ).unwrap());
+        bar.enable_steady_tick(Duration::from_millis(100));
     }
 
     let black = Color::new(0.0, 0.0, 0.0);

--- a/clovers/Cargo.toml
+++ b/clovers/Cargo.toml
@@ -18,12 +18,12 @@ std = []
 traces = ["tracing"]
 
 [dependencies]
-enum_dispatch = "0.3.8"
+enum_dispatch = "0.3.9"
 gltf = { version = "1.0.0", optional = true }
 nalgebra = { version = "0.31.4", features = ["libm"], default-features = false }
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }
 rand_distr = "0.4.3"
-serde = { version = "1.0.150", features = ["derive"], default-features = false, optional = true }
+serde = { version = "1.0.152", features = ["derive"], default-features = false, optional = true }
 stl_io = { version = "0.7.0", optional = true }
 tracing = { version = "0.1.37", optional = true }
 


### PR DESCRIPTION
- enable `indicatif` steady tick, see
  - https://github.com/console-rs/indicatif/issues/394
  - https://github.com/console-rs/indicatif/issues/493
  - https://github.com/console-rs/indicatif/pull/495
- run `cargo upgrade`