### PR TITLE
refactor: massive lifetime refactoring

### DIFF
--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -26,4 +26,3 @@ serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 time = { version = "0.3.20", default-features = false }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["time"] }
-bumpalo = { version = "3.12.0", features = ["boxed"] }

--- a/clovers-cli/src/json_scene.rs
+++ b/clovers-cli/src/json_scene.rs
@@ -5,14 +5,12 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use bumpalo::{boxed::Box, Bump};
 use tracing::info;
 
 pub(crate) fn initialize<'scene>(
     path: &Path,
     opts: &Opts,
-    bump: &'scene Bump,
-) -> Result<Box<'scene, Scene>, std::boxed::Box<dyn Error>> {
+) -> Result<Box<Scene<'scene>>, std::boxed::Box<dyn Error>> {
     let mut file = File::open(path)?;
     let mut contents: String = String::new();
     file.read_to_string(&mut contents)?;
@@ -21,5 +19,5 @@ pub(crate) fn initialize<'scene>(
     info!("Initializing the scene");
     let scene: Scene = scenes::initialize(scene_file, opts.width, opts.height);
     info!("Count of nodes in the BVH tree: {}", scene.objects.count());
-    Ok(Box::new_in(scene, bump))
+    Ok(Box::new(scene))
 }

--- a/clovers-cli/src/json_scene.rs
+++ b/clovers-cli/src/json_scene.rs
@@ -10,7 +10,7 @@ use tracing::info;
 pub(crate) fn initialize<'scene>(
     path: &Path,
     opts: &Opts,
-) -> Result<Box<Scene<'scene>>, std::boxed::Box<dyn Error>> {
+) -> Result<Scene<'scene>, Box<dyn Error>> {
     let mut file = File::open(path)?;
     let mut contents: String = String::new();
     file.read_to_string(&mut contents)?;
@@ -19,5 +19,5 @@ pub(crate) fn initialize<'scene>(
     info!("Initializing the scene");
     let scene: Scene = scenes::initialize(scene_file, opts.width, opts.height);
     info!("Count of nodes in the BVH tree: {}", scene.objects.count());
-    Ok(Box::new(scene))
+    Ok(scene)
 }

--- a/clovers-cli/src/main.rs
+++ b/clovers-cli/src/main.rs
@@ -5,7 +5,6 @@
 #![deny(clippy::all)]
 
 // External imports
-use bumpalo::Bump;
 use clap::Parser;
 use human_format::Formatter;
 use humantime::format_duration;
@@ -103,14 +102,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     let threads = std::thread::available_parallelism()?;
 
-    // Bump allocated arena
-    let bump = Bump::new();
-
     info!("Reading the scene file");
     let path = Path::new(&opts.input);
     let scene = match path.extension() {
         Some(ext) => match &ext.to_str() {
-            Some("json") => json_scene::initialize(path, &opts, &bump),
+            Some("json") => json_scene::initialize(path, &opts),
             _ => panic!("Unknown file type"),
         },
         None => panic!("Unknown file type"),

--- a/clovers/src/aabb.rs
+++ b/clovers/src/aabb.rs
@@ -7,7 +7,7 @@ use crate::{interval::Interval, ray::Ray, Float, Vec3, EPSILON_RECT_THICKNESS};
 /// Axis-aligned bounding box Defined by two opposing corners, each of which are a [Vec3].
 ///
 /// This is useful for creating bounding volume hierarchies, which is an optimization for reducing the time spent on calculating ray-object intersections.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct AABB {
     /// The bounding interval on the X axis
@@ -104,7 +104,7 @@ impl AABB {
 
     /// Given two axis-aligned bounding boxes, return a new [AABB] that contains both.
     #[must_use]
-    pub fn surrounding_box(box0: AABB, box1: AABB) -> AABB {
+    pub fn surrounding_box(box0: &AABB, box1: &AABB) -> AABB {
         AABB {
             x: Interval::new_from_intervals(box0.x, box1.x),
             y: Interval::new_from_intervals(box0.y, box1.y),
@@ -138,7 +138,7 @@ impl AABB {
     /// Returns the interval of the given axis.
     // TODO: this api is kind of annoying
     #[must_use]
-    pub fn axis(self, n: usize) -> Interval {
+    pub fn axis(&self, n: usize) -> Interval {
         match n {
             0 => self.x,
             1 => self.y,

--- a/clovers/src/bvhnode.rs
+++ b/clovers/src/bvhnode.rs
@@ -56,7 +56,7 @@ impl<'scene> BVHNode<'scene> {
             // TODO: can this hack be removed?
             left = Box::new(objects[0].clone());
             right = Box::new(Hitable::Empty(Empty {}));
-            let bounding_box = left.bounding_box(time_0, time_1).unwrap(); // TODO: remove unwrap
+            let bounding_box = left.bounding_box(time_0, time_1).unwrap().clone(); // TODO: remove unwrap
             return BVHNode {
                 left,
                 right,
@@ -122,7 +122,7 @@ impl<'scene> BVHNode<'scene> {
                 bounding_box,
             }
         } else {
-            panic!("No bounding box in bvh_node constructor. {box_left:?} {box_right:?}");
+            panic!("No bounding box in bvh_node constructor");
         }
     }
 
@@ -178,8 +178,8 @@ impl<'scene> HitableTrait for BVHNode<'scene> {
 
     /// Returns the axis-aligned bounding box [AABB] of the objects within this [`BVHNode`].
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t11: Float) -> Option<AABB> {
-        Some(self.bounding_box)
+    fn bounding_box(&self, _t0: Float, _t11: Float) -> Option<&AABB> {
+        Some(&self.bounding_box)
     }
 
     /// Returns a probability density function value based on the children
@@ -215,8 +215,8 @@ impl<'scene> HitableTrait for BVHNode<'scene> {
 
 fn box_compare(a: &Hitable, b: &Hitable, axis: usize) -> Ordering {
     // TODO: proper time support?
-    let box_a: Option<AABB> = a.bounding_box(0.0, 1.0);
-    let box_b: Option<AABB> = b.bounding_box(0.0, 1.0);
+    let box_a: Option<&AABB> = a.bounding_box(0.0, 1.0);
+    let box_b: Option<&AABB> = b.bounding_box(0.0, 1.0);
 
     if let (Some(box_a), Some(box_b)) = (box_a, box_b) {
         if box_a.axis(axis).min < box_b.axis(axis).min {
@@ -265,11 +265,11 @@ fn vec_bounding_box(vec: &Vec<Hitable>, t0: Float, t1: Float) -> Option<AABB> {
         match output_box {
             // If we do, expand it & recurse
             Some(old_box) => {
-                output_box = Some(AABB::surrounding_box(old_box, bounding));
+                output_box = Some(AABB::surrounding_box(&old_box, bounding));
             }
             // Otherwise, set output box to be the newly-found box
             None => {
-                output_box = Some(bounding);
+                output_box = Some(bounding.clone());
             }
         }
     }

--- a/clovers/src/bvhnode.rs
+++ b/clovers/src/bvhnode.rs
@@ -15,16 +15,16 @@ use crate::{
 ///
 /// A node in a tree structure defining a hierarchy of objects in a scene: a node knows its bounding box, and has two children which are also `BVHNode`s. This is used for accelerating the ray-object intersection calculation in the ray tracer. See [Bounding Volume hierarchies](https://raytracing.github.io/books/RayTracingTheNextWeek.html)
 #[derive(Debug, Clone)]
-pub struct BVHNode {
+pub struct BVHNode<'scene> {
     /// Left child of the BVHNode
-    pub left: Box<Hitable>,
+    pub left: Box<Hitable<'scene>>,
     /// Right child of the BVHNode
-    pub right: Box<Hitable>,
+    pub right: Box<Hitable<'scene>>,
     /// Bounding box containing both of the child nodes
     pub bounding_box: AABB,
 }
 
-impl BVHNode {
+impl<'scene> BVHNode<'scene> {
     /// Create a new `BVHNode` tree from a given list of [Object](crate::objects::Object)s
     #[must_use]
     pub fn from_list(mut objects: Vec<Hitable>, time_0: Float, time_1: Float) -> BVHNode {
@@ -142,7 +142,7 @@ impl BVHNode {
     }
 }
 
-impl HitableTrait for BVHNode {
+impl<'scene> HitableTrait for BVHNode<'scene> {
     /// The main `hit` function for a [`BVHNode`]. Given a [Ray](crate::ray::Ray), and an interval `distance_min` and `distance_max`, returns either `None` or `Some(HitRecord)` based on whether the ray intersects with the encased objects during that interval.
     #[must_use]
     fn hit(

--- a/clovers/src/camera.rs
+++ b/clovers/src/camera.rs
@@ -33,7 +33,7 @@ pub struct Camera {
     pub w: Vec3,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Represents the fields that can be described in a Scene file. Some other fields the main Camera struct requires (such as `aspect_ratio`) are derived from other info (such as width, height)
 pub struct CameraInit {

--- a/clovers/src/colorize.rs
+++ b/clovers/src/colorize.rs
@@ -3,7 +3,7 @@
 use crate::{
     color::Color,
     hitable::HitableTrait,
-    materials::{MaterialTrait, MaterialType},
+    materials::MaterialType,
     pdf::{HitablePDF, MixturePDF, PDFTrait, PDF},
     ray::Ray,
     scenes::Scene,

--- a/clovers/src/hitable.rs
+++ b/clovers/src/hitable.rs
@@ -35,7 +35,7 @@ pub struct HitRecord<'a> {
     /// V surface coordinate of the hitpoint
     pub v: Float,
     /// Reference to the material at the hitpoint
-    pub material: &'a Material,
+    pub material: &'a Material<'a>,
     /// Is the hitpoint at the front of the surface
     pub front_face: bool,
 }
@@ -55,24 +55,24 @@ impl<'a> HitRecord<'a> {
 /// An abstraction for things that can be hit by [Rays](crate::ray::Ray).
 #[enum_dispatch(HitableTrait)]
 #[derive(Debug, Clone)]
-pub enum Hitable {
-    Boxy(Boxy),
-    BVHNode(BVHNode),
-    ConstantMedium(ConstantMedium),
-    FlipFace(FlipFace),
-    MovingSphere(MovingSphere),
-    Quad(Quad),
-    RotateY(RotateY),
-    Sphere(Sphere),
+pub enum Hitable<'scene> {
+    Boxy(Boxy<'scene>),
+    BVHNode(BVHNode<'scene>),
+    ConstantMedium(ConstantMedium<'scene>),
+    FlipFace(FlipFace<'scene>),
+    MovingSphere(MovingSphere<'scene>),
+    Quad(Quad<'scene>),
+    RotateY(RotateY<'scene>),
+    Sphere(Sphere<'scene>),
     #[cfg(feature = "stl")]
-    STL(STL),
+    STL(STL<'scene>),
     #[cfg(feature = "gl_tf")]
-    GLTF(GLTF),
-    Translate(Translate),
-    Triangle(Triangle),
+    GLTF(GLTF<'scene>),
+    Translate(Translate<'scene>),
+    Triangle(Triangle<'scene>),
     Empty(Empty),
     #[cfg(feature = "gl_tf")]
-    GLTFTriangle(GLTFTriangle),
+    GLTFTriangle(GLTFTriangle<'scene>),
 }
 
 // TODO: remove horrible hack

--- a/clovers/src/hitable.rs
+++ b/clovers/src/hitable.rs
@@ -10,7 +10,7 @@ use crate::objects::{GLTFTriangle, GLTF};
 use crate::{
     aabb::AABB,
     bvhnode::BVHNode,
-    materials::Material,
+    materials::MaterialTrait,
     objects::{
         Boxy, ConstantMedium, FlipFace, MovingSphere, Quad, RotateY, Sphere, Translate, Triangle,
     },
@@ -35,7 +35,7 @@ pub struct HitRecord<'a> {
     /// V surface coordinate of the hitpoint
     pub v: Float,
     /// Reference to the material at the hitpoint
-    pub material: &'a Material<'a>,
+    pub material: &'a dyn MaterialTrait,
     /// Is the hitpoint at the front of the surface
     pub front_face: bool,
 }

--- a/clovers/src/hitable.rs
+++ b/clovers/src/hitable.rs
@@ -90,7 +90,7 @@ impl HitableTrait for Empty {
         None
     }
 
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
         None
     }
 
@@ -115,7 +115,7 @@ pub(crate) trait HitableTrait {
     ) -> Option<HitRecord>;
 
     #[must_use]
-    fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB>;
+    fn bounding_box(&self, t0: Float, t1: Float) -> Option<&AABB>;
 
     #[must_use]
     fn pdf_value(&self, origin: Vec3, vector: Vec3, time: Float, rng: &mut SmallRng) -> Float;

--- a/clovers/src/interval.rs
+++ b/clovers/src/interval.rs
@@ -5,7 +5,7 @@ use core::ops::Add;
 use crate::Float;
 
 /// An interval structure.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct Interval {
     /// Smallest value of the interval. Must be kept in order  

--- a/clovers/src/lib.rs
+++ b/clovers/src/lib.rs
@@ -92,7 +92,7 @@ pub mod scenes;
 pub mod textures;
 
 /// Rendering options struct
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderOpts {
     /// Width of the render in pixels

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -1,5 +1,7 @@
 //! Materials enable different behaviors of light on objects.
 
+use core::fmt::Debug;
+
 use crate::{color::Color, hitable::HitRecord, pdf::PDF, ray::Ray, Float, Vec3};
 pub mod dielectric;
 pub mod diffuse_light;
@@ -17,11 +19,10 @@ pub use lambertian::*;
 pub use metal::*;
 use rand::prelude::SmallRng;
 
-#[cfg(feature = "gl_tf")]
-use self::gltf::GLTFMaterial;
-
 #[enum_dispatch]
-pub(crate) trait MaterialTrait {
+/// Trait for materials. Requires three function implementations: `scatter`, `scattering_pdf`, and `emit`.
+pub trait MaterialTrait: Debug {
+    /// Given a ray and a hitrecord, return the possible `ScatterRecord`.
     fn scatter(
         &self,
         ray: &Ray,
@@ -29,6 +30,7 @@ pub(crate) trait MaterialTrait {
         rng: &mut SmallRng,
     ) -> Option<ScatterRecord>;
 
+    /// TODO: explain
     fn scattering_pdf(
         &self,
         hit_record: &HitRecord,
@@ -36,6 +38,7 @@ pub(crate) trait MaterialTrait {
         rng: &mut SmallRng,
     ) -> Option<Float>;
 
+    /// Returns the emissivity of the material at the given position.
     fn emit(
         &self,
         _ray: &Ray,
@@ -54,7 +57,7 @@ pub(crate) trait MaterialTrait {
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A material enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 #[cfg_attr(feature = "serde-derive", serde(tag = "kind"))]
-pub enum Material<'scene> {
+pub enum Material {
     /// Dielectric material
     Dielectric(Dielectric),
     /// Lambertian material
@@ -65,13 +68,9 @@ pub enum Material<'scene> {
     Metal(Metal),
     /// Isotropic material
     Isotropic(Isotropic),
-    /// GLTF material
-    #[cfg(feature = "gl_tf")]
-    #[cfg_attr(feature = "serde-derive", serde(skip))]
-    GLTF(GLTFMaterial<'scene>),
 }
 
-impl<'scene> Default for Material<'scene> {
+impl Default for Material {
     fn default() -> Self {
         Self::Lambertian(Lambertian::default())
     }

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -50,7 +50,7 @@ pub(crate) trait MaterialTrait {
 }
 
 #[enum_dispatch(MaterialTrait)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A material enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 #[cfg_attr(feature = "serde-derive", serde(tag = "kind"))]

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -54,7 +54,7 @@ pub(crate) trait MaterialTrait {
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A material enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 #[cfg_attr(feature = "serde-derive", serde(tag = "kind"))]
-pub enum Material {
+pub enum Material<'scene> {
     /// Dielectric material
     Dielectric(Dielectric),
     /// Lambertian material
@@ -68,10 +68,10 @@ pub enum Material {
     /// GLTF material
     #[cfg(feature = "gl_tf")]
     #[cfg_attr(feature = "serde-derive", serde(skip))]
-    GLTF(GLTFMaterial),
+    GLTF(GLTFMaterial<'scene>),
 }
 
-impl Default for Material {
+impl<'scene> Default for Material<'scene> {
     fn default() -> Self {
         Self::Lambertian(Lambertian::default())
     }

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -77,7 +77,7 @@ impl<'scene> Default for Material<'scene> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 /// Enum for the types of materials: Diffuse and Specular (i.e., matte and shiny)
 pub enum MaterialType {
     /// A matte material that does not reflect rays

--- a/clovers/src/materials/dielectric.rs
+++ b/clovers/src/materials/dielectric.rs
@@ -11,7 +11,7 @@ use crate::{
 use rand::rngs::SmallRng;
 use rand::Rng;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A dielectric material. This resembles glass and other transparent and reflective materials.
 pub struct Dielectric {

--- a/clovers/src/materials/diffuse_light.rs
+++ b/clovers/src/materials/diffuse_light.rs
@@ -11,7 +11,7 @@ use crate::{
 use rand::prelude::SmallRng;
 
 /// A diffuse light material. On this material, rays never scatter - the material always emits a color based on its texture.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct DiffuseLight {
     emit: Texture,

--- a/clovers/src/materials/gltf.rs
+++ b/clovers/src/materials/gltf.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{reflect, MaterialTrait, MaterialType, ScatterRecord};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 // #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// GLTF Material wrapper type
 pub struct GLTFMaterial<'scene> {

--- a/clovers/src/materials/gltf.rs
+++ b/clovers/src/materials/gltf.rs
@@ -20,30 +20,30 @@ use super::{reflect, MaterialTrait, MaterialType, ScatterRecord};
 #[derive(Debug, Copy, Clone)]
 // #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// GLTF Material wrapper type
-pub struct GLTFMaterial {
-    material: &'static Material<'static>,
+pub struct GLTFMaterial<'scene> {
+    material: &'scene Material<'scene>,
     tex_coords: [[Float; 2]; 3],
-    images: &'static [Data],
+    images: &'scene [Data],
     tangents: Option<[Vec3; 3]>,
     normals: Option<[Vec3; 3]>,
     bitangents: Option<[Vec3; 3]>,
 }
 
-impl Default for GLTFMaterial {
+impl<'scene> Default for GLTFMaterial<'scene> {
     fn default() -> Self {
         todo!()
     }
 }
 
-impl GLTFMaterial {
+impl<'scene> GLTFMaterial<'scene> {
     /// Initialize a new GLTF material wrapper
     #[must_use]
     pub fn new(
-        material: &'static Material,
+        material: &'scene Material,
         tex_coords: [[Float; 2]; 3],
         normals: Option<[[Float; 3]; 3]>,
         tangents: Option<[[Float; 4]; 3]>,
-        images: &'static [Data],
+        images: &'scene [Data],
     ) -> Self {
         let normals: Option<[Vec3; 3]> = normals.map(|ns| ns.map(Vec3::from));
         let tangents: Option<[Vec4; 3]> = tangents.map(|ns| ns.map(Vec4::from));
@@ -77,7 +77,7 @@ impl GLTFMaterial {
     }
 }
 
-impl MaterialTrait for GLTFMaterial {
+impl<'scene> MaterialTrait for GLTFMaterial<'scene> {
     fn scatter(
         &self,
         ray: &Ray,
@@ -132,7 +132,7 @@ impl MaterialTrait for GLTFMaterial {
     }
 }
 
-impl GLTFMaterial {
+impl<'scene> GLTFMaterial<'scene> {
     fn sample_base_color(&self, hit_record: &HitRecord) -> Color {
         let base_color_texture = self
             .material

--- a/clovers/src/materials/isotropic.rs
+++ b/clovers/src/materials/isotropic.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use rand::prelude::SmallRng;
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Isotropic material. Used in [`ConstantMedium`](crate::objects::constant_medium). TODO: understand this!
 pub struct Isotropic {

--- a/clovers/src/materials/lambertian.rs
+++ b/clovers/src/materials/lambertian.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use rand::prelude::SmallRng;
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// Lambertian material. This is the default material with a smooth, matte surface.
 pub struct Lambertian {

--- a/clovers/src/materials/metal.rs
+++ b/clovers/src/materials/metal.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use rand::prelude::SmallRng;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A metal material. The amount of reflection can be adjusted with the `fuzz` parameter.
 pub struct Metal {

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -36,47 +36,47 @@ pub use triangle::*;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A list of objects. Allows multiple objects to be used e.g. in a Rotate or Translate object as the target.
-pub struct ObjectList {
+pub struct ObjectList<'scene> {
     /// The encased [Object] list
-    pub objects: Vec<Object>,
+    pub objects: Vec<Object<'scene>>,
 }
 
 #[derive(Clone, Debug)]
 /// An object enum. TODO: for ideal clean abstraction, this should be a trait. However, that comes with some additional considerations, including e.g. performance.
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde-derive", serde(tag = "kind"))]
-pub enum Object {
+pub enum Object<'scene> {
     /// Boxy object initializer
-    Boxy(BoxyInit),
+    Boxy(BoxyInit<'scene>),
     /// ConstantMedium object initializer
-    ConstantMedium(ConstantMediumInit),
+    ConstantMedium(ConstantMediumInit<'scene>),
     /// FlipFace object initializer
-    FlipFace(FlipFaceInit),
+    FlipFace(FlipFaceInit<'scene>),
     /// MovingSphere object initializer
-    MovingSphere(MovingSphereInit),
+    MovingSphere(MovingSphereInit<'scene>),
     /// ObjectList object initializer
-    ObjectList(ObjectList),
+    ObjectList(ObjectList<'scene>),
     /// Quad object initializer
-    Quad(QuadInit),
+    Quad(QuadInit<'scene>),
     /// RotateY object initializer
-    RotateY(RotateInit),
+    RotateY(RotateInit<'scene>),
     /// Sphere object initializer
-    Sphere(SphereInit),
+    Sphere(SphereInit<'scene>),
     #[cfg(feature = "stl")]
     /// STL object initializer
-    STL(STLInit),
+    STL(STLInit<'scene>),
     #[cfg(feature = "gl_tf")]
     /// GLTF object initializer
     GLTF(GLTFInit),
     /// Translate object initializer
-    Translate(TranslateInit),
+    Translate(TranslateInit<'scene>),
     /// Triangle object initializer
-    Triangle(TriangleInit),
+    Triangle(TriangleInit<'scene>),
 }
 
-impl From<Object> for Hitable {
+impl<'scene> From<Object<'scene>> for Hitable<'scene> {
     #[must_use]
-    fn from(obj: Object) -> Hitable {
+    fn from(obj: Object<'scene>) -> Hitable<'scene> {
         match obj {
             Object::Boxy(x) => Hitable::Boxy(Boxy::new(x.corner_0, x.corner_1, x.material)),
             Object::ConstantMedium(x) => {
@@ -125,7 +125,8 @@ impl From<Object> for Hitable {
                 Hitable::Translate(Translate::new(Box::new(obj), x.offset))
             }
             Object::Triangle(x) => {
-                let material: &'static Material = Box::leak(Box::new(x.material));
+                // TODO: do not leak memory
+                let material: &'scene Material = Box::leak(Box::new(x.material));
                 Hitable::Triangle(Triangle::new(x.q, x.u, x.v, material))
             }
         }

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -78,7 +78,11 @@ impl<'scene> From<Object<'scene>> for Hitable<'scene> {
     #[must_use]
     fn from(obj: Object<'scene>) -> Hitable<'scene> {
         match obj {
-            Object::Boxy(x) => Hitable::Boxy(Boxy::new(x.corner_0, x.corner_1, x.material)),
+            Object::Boxy(x) => {
+                // TODO: do not leak memory
+                let material: &'scene Material = Box::leak(Box::new(x.material));
+                Hitable::Boxy(Boxy::new(x.corner_0, x.corner_1, material))
+            }
             Object::ConstantMedium(x) => {
                 let obj = *x.boundary;
                 let obj: Hitable = obj.into();
@@ -102,7 +106,11 @@ impl<'scene> From<Object<'scene>> for Hitable<'scene> {
                 let bvh = BVHNode::from_list(objects, 0.0, 1.0);
                 Hitable::BVHNode(bvh)
             }
-            Object::Quad(x) => Hitable::Quad(Quad::new(x.q, x.u, x.v, x.material)),
+            Object::Quad(x) => {
+                // TODO: do not leak memory
+                let material: &'scene Material = Box::leak(Box::new(x.material));
+                Hitable::Quad(Quad::new(x.q, x.u, x.v, material))
+            }
             Object::RotateY(x) => {
                 let obj = *x.object;
                 let obj: Hitable = obj.into();

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -112,6 +112,8 @@ impl<'scene> From<Object<'scene>> for Hitable<'scene> {
             #[cfg(feature = "stl")]
             Object::STL(x) => {
                 // TODO: time
+                // TODO: do not leak memory
+                let x: &'scene STLInit = Box::leak(Box::new(x));
                 Hitable::STL(STL::new(x, 0.0, 1.0))
             }
             #[cfg(feature = "gl_tf")]

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -102,8 +102,8 @@ impl<'scene> HitableTrait for Boxy<'scene> {
 
     /// Returns the axis-aligned bounding box [AABB] of the object.
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value? // TODO: understand & explain

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -13,30 +13,30 @@ use rand::{rngs::SmallRng, Rng};
 /// `BoxyInit` structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct BoxyInit {
+pub struct BoxyInit<'scene> {
     /// First corner for the box
     pub corner_0: Vec3,
     /// Second, opposing corner for the box
     pub corner_1: Vec3,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material used for the box
-    pub material: Material,
+    pub material: Material<'scene>,
 }
 
 /// A box or a cuboid object: a parallelepiped with six rectangular faces. Named [Boxy] to avoid clashing with [Box].
 #[derive(Debug, Clone)]
-pub struct Boxy {
-    sides: Box<[Hitable; 6]>,
+pub struct Boxy<'scene> {
+    sides: Box<[Hitable<'scene>; 6]>,
     /// The material of the box
-    pub material: Material,
+    pub material: Material<'scene>,
     /// Axis-aligned bounding box
     pub aabb: AABB,
 }
 
-impl Boxy {
+impl<'scene> Boxy<'scene> {
     /// Initializes a new instance of a box, given two opposing [Vec3] corners `corner_0` and `corner_1`, and a [Material] `material`.
     #[must_use]
-    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material) -> Self {
+    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material<'scene>) -> Self {
         // Construct the two opposite vertices with the minimum and maximum coordinates.
         let min: Vec3 = Vec3::new(
             corner_0.x.min(corner_1.x),
@@ -78,7 +78,7 @@ impl Boxy {
     }
 }
 
-impl HitableTrait for Boxy {
+impl<'scene> HitableTrait for Boxy<'scene> {
     /// The main `hit` function for a [Boxy]. Given a [Ray](crate::ray::Ray), and an interval `distance_min` and `distance_max`, returns either `None` or `Some(HitRecord)` based on whether the ray intersects with the object during that interval.
     #[must_use]
     fn hit(

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -11,7 +11,7 @@ use crate::{
 use rand::{rngs::SmallRng, Rng};
 
 /// `BoxyInit` structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoxyInit<'scene> {
     /// First corner for the box
@@ -28,7 +28,7 @@ pub struct BoxyInit<'scene> {
 pub struct Boxy<'scene> {
     sides: Box<[Hitable<'scene>; 6]>,
     /// The material of the box
-    pub material: Material<'scene>,
+    pub material: &'scene Material<'scene>,
     /// Axis-aligned bounding box
     pub aabb: AABB,
 }
@@ -36,7 +36,7 @@ pub struct Boxy<'scene> {
 impl<'scene> Boxy<'scene> {
     /// Initializes a new instance of a box, given two opposing [Vec3] corners `corner_0` and `corner_1`, and a [Material] `material`.
     #[must_use]
-    pub fn new(corner_0: Vec3, corner_1: Vec3, material: Material<'scene>) -> Self {
+    pub fn new(corner_0: Vec3, corner_1: Vec3, material: &'scene Material<'scene>) -> Self {
         // Construct the two opposite vertices with the minimum and maximum coordinates.
         let min: Vec3 = Vec3::new(
             corner_0.x.min(corner_1.x),

--- a/clovers/src/objects/boxy.rs
+++ b/clovers/src/objects/boxy.rs
@@ -13,14 +13,14 @@ use rand::{rngs::SmallRng, Rng};
 /// `BoxyInit` structure describes the necessary data for constructing a [Boxy]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct BoxyInit<'scene> {
+pub struct BoxyInit {
     /// First corner for the box
     pub corner_0: Vec3,
     /// Second, opposing corner for the box
     pub corner_1: Vec3,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material used for the box
-    pub material: Material<'scene>,
+    pub material: Material,
 }
 
 /// A box or a cuboid object: a parallelepiped with six rectangular faces. Named [Boxy] to avoid clashing with [Box].
@@ -28,7 +28,7 @@ pub struct BoxyInit<'scene> {
 pub struct Boxy<'scene> {
     sides: Box<[Hitable<'scene>; 6]>,
     /// The material of the box
-    pub material: &'scene Material<'scene>,
+    pub material: &'scene Material,
     /// Axis-aligned bounding box
     pub aabb: AABB,
 }
@@ -36,7 +36,7 @@ pub struct Boxy<'scene> {
 impl<'scene> Boxy<'scene> {
     /// Initializes a new instance of a box, given two opposing [Vec3] corners `corner_0` and `corner_1`, and a [Material] `material`.
     #[must_use]
-    pub fn new(corner_0: Vec3, corner_1: Vec3, material: &'scene Material<'scene>) -> Self {
+    pub fn new(corner_0: Vec3, corner_1: Vec3, material: &'scene Material) -> Self {
         // Construct the two opposite vertices with the minimum and maximum coordinates.
         let min: Vec3 = Vec3::new(
             corner_0.x.min(corner_1.x),

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -17,9 +17,9 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `ConstantMediumInit` structure describes the necessary data for constructing a [`ConstantMedium`]. Used with [serde] when importing [`SceneFiles`](crate::scenes::SceneFile).
-pub struct ConstantMediumInit {
+pub struct ConstantMediumInit<'scene> {
     /// The boundary object for the constant medium. This determines the size and shape of the fog object.
-    pub boundary: Box<Object>,
+    pub boundary: Box<Object<'scene>>,
     #[cfg_attr(feature = "serde-derive", serde(default = "default_density"))]
     /// Density of the fog. TODO: example good value range?
     pub density: Float,
@@ -38,16 +38,16 @@ fn default_density() -> Float {
 
 #[derive(Debug, Clone)]
 /// `ConstantMedium` object. This should probably be a [Material] at some point, but this will do for now. This is essentially a fog with a known size, shape and density.
-pub struct ConstantMedium {
-    boundary: Box<Hitable>,
-    phase_function: Material,
+pub struct ConstantMedium<'scene> {
+    boundary: Box<Hitable<'scene>>,
+    phase_function: Material<'scene>,
     neg_inv_density: Float,
 }
 
-impl ConstantMedium {
+impl<'scene> ConstantMedium<'scene> {
     /// Creates a new [`ConstantMedium`] with a known size, shape and density.
     #[must_use]
-    pub fn new(boundary: Box<Hitable>, density: Float, texture: Texture) -> Self {
+    pub fn new(boundary: Box<Hitable<'scene>>, density: Float, texture: Texture) -> Self {
         ConstantMedium {
             boundary,
             phase_function: Material::Isotropic(Isotropic::new(texture)),
@@ -56,7 +56,7 @@ impl ConstantMedium {
     }
 }
 
-impl HitableTrait for ConstantMedium {
+impl<'scene> HitableTrait for ConstantMedium<'scene> {
     /// Hit function for the [`ConstantMedium`] object. Returns a [`HitRecord`] if hit. TODO: explain the math for the fog
     #[must_use]
     fn hit(

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -130,7 +130,7 @@ impl<'scene> HitableTrait for ConstantMedium<'scene> {
 
     /// Returns the axis-aligned bounding box [AABB] of the defining `boundary` object for the fog.
     #[must_use]
-    fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB> {
+    fn bounding_box(&self, t0: Float, t1: Float) -> Option<&AABB> {
         self.boundary.bounding_box(t0, t1)
     }
 

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -17,9 +17,9 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `ConstantMediumInit` structure describes the necessary data for constructing a [`ConstantMedium`]. Used with [serde] when importing [`SceneFiles`](crate::scenes::SceneFile).
-pub struct ConstantMediumInit<'scene> {
+pub struct ConstantMediumInit {
     /// The boundary object for the constant medium. This determines the size and shape of the fog object.
-    pub boundary: Box<Object<'scene>>,
+    pub boundary: Box<Object>,
     #[cfg_attr(feature = "serde-derive", serde(default = "default_density"))]
     /// Density of the fog. TODO: example good value range?
     pub density: Float,
@@ -40,7 +40,7 @@ fn default_density() -> Float {
 /// `ConstantMedium` object. This should probably be a [Material] at some point, but this will do for now. This is essentially a fog with a known size, shape and density.
 pub struct ConstantMedium<'scene> {
     boundary: Box<Hitable<'scene>>,
-    phase_function: Material<'scene>,
+    phase_function: Material,
     neg_inv_density: Float,
 }
 

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -13,30 +13,30 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `FlipFaceInit` structure describes the necessary data for constructing a [`FlipFace`]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct FlipFaceInit {
+pub struct FlipFaceInit<'scene> {
     /// The object to wrap with the face flipping feature.
-    pub object: Box<Object>,
+    pub object: Box<Object<'scene>>,
 }
 
 #[derive(Debug, Clone)]
 /// An utility object that can be used to flip the face of the object. TODO: possibly deprecated?
-pub struct FlipFace {
-    object: Box<Hitable>,
+pub struct FlipFace<'scene> {
+    object: Box<Hitable<'scene>>,
 }
 
-impl FlipFace {
+impl<'scene> FlipFace<'scene> {
     // TODO: possibly deprecate / remove?
 
     /// Creates a new instance of a [`FlipFace`]
     #[must_use]
-    pub fn new(object: Hitable) -> Self {
+    pub fn new(object: Hitable<'scene>) -> Self {
         FlipFace {
             object: Box::new(object),
         }
     }
 }
 
-impl HitableTrait for FlipFace {
+impl<'scene> HitableTrait for FlipFace<'scene> {
     /// Hit function for the [`FlipFace`] object. Considering this is a utility object that wraps an internal `object`, it returns a [`HitRecord`] with the `front_face` property flipped, if the given [Ray] hits the object.
     #[must_use]
     fn hit(

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -13,9 +13,9 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `FlipFaceInit` structure describes the necessary data for constructing a [`FlipFace`]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct FlipFaceInit<'scene> {
+pub struct FlipFaceInit {
     /// The object to wrap with the face flipping feature.
-    pub object: Box<Object<'scene>>,
+    pub object: Box<Object>,
 }
 
 #[derive(Debug, Clone)]

--- a/clovers/src/objects/flip_face.rs
+++ b/clovers/src/objects/flip_face.rs
@@ -56,7 +56,7 @@ impl<'scene> HitableTrait for FlipFace<'scene> {
 
     /// Returns the axis-aligned bounding box [AABB] of the [`FlipFace`] object. Considering this is a utility object that wraps an internal `object`, it returns the bounding box of the internal object.
     #[must_use]
-    fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB> {
+    fn bounding_box(&self, t0: Float, t1: Float) -> Option<&AABB> {
         self.object.bounding_box(t0, t1)
     }
 

--- a/clovers/src/objects/gltf.rs
+++ b/clovers/src/objects/gltf.rs
@@ -67,7 +67,7 @@ impl<'scene> GLTF<'scene> {
         let triangles: Vec<Hitable> = gltf_init.into();
         let bvhnode = BVHNode::from_list(triangles, time_0, time_1);
         // TODO: remove unwrap
-        let aabb = bvhnode.bounding_box(time_0, time_1).unwrap();
+        let aabb = bvhnode.bounding_box(time_0, time_1).unwrap().clone();
 
         GLTF { bvhnode, aabb }
     }
@@ -88,8 +88,8 @@ impl<'scene> HitableTrait for GLTF<'scene> {
 
     /// Return the axis-aligned bounding box for the object
     #[must_use]
-    fn bounding_box(&self, _t0: f32, _t1: f32) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: f32, _t1: f32) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value based on the object
@@ -320,8 +320,8 @@ impl<'scene> HitableTrait for GLTFTriangle<'scene> {
         })
     }
 
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     fn pdf_value(&self, origin: Vec3, vector: Vec3, time: Float, rng: &mut SmallRng) -> Float {

--- a/clovers/src/objects/gltf.rs
+++ b/clovers/src/objects/gltf.rs
@@ -14,7 +14,7 @@ use crate::{
     bvhnode::BVHNode,
     hitable::{get_orientation, HitRecord, Hitable, HitableTrait},
     interval::Interval,
-    materials::{gltf::GLTFMaterial, Material},
+    materials::gltf::GLTFMaterial,
     ray::Ray,
     Float, Vec3, EPSILON_RECT_THICKNESS, EPSILON_SHADOW_ACNE,
 };
@@ -196,9 +196,9 @@ fn parse_mesh<'scene>(
                         });
 
                         // TODO: don't leak memory
-                        let material: &'scene Material = Box::leak(Box::new(Material::GLTF(
+                        let material: &'scene GLTFMaterial = Box::leak(Box::new(
                             GLTFMaterial::new(material, tex_coords, normals, tangents, images),
-                        )));
+                        ));
 
                         let gltf_triangle = GLTFTriangle::new(triangle, material);
                         trianglelist.push(Hitable::GLTFTriangle(gltf_triangle));
@@ -220,7 +220,7 @@ pub struct GLTFTriangle<'scene> {
     /// Axis-aligned bounding box of the object
     pub aabb: AABB,
     /// Material of the object
-    pub material: &'scene Material<'scene>,
+    pub material: &'scene GLTFMaterial<'scene>,
     q: Vec3,
     u: Vec3,
     v: Vec3,
@@ -233,7 +233,7 @@ pub struct GLTFTriangle<'scene> {
 impl<'scene> GLTFTriangle<'scene> {
     #[must_use]
     /// Initialize a new GLTF object
-    pub fn new(triangle: [Vec3; 3], material: &'scene Material) -> Self {
+    pub fn new(triangle: [Vec3; 3], material: &'scene GLTFMaterial<'scene>) -> Self {
         // TODO: mostly adapted from Triangle, verify correctness!
 
         let [a, b, c] = triangle;

--- a/clovers/src/objects/gltf.rs
+++ b/clovers/src/objects/gltf.rs
@@ -33,9 +33,9 @@ impl<'scene> From<GLTFInit> for Vec<Hitable<'scene>> {
 
         // Go through the objects in the gltf file
         let (document, buffers, images) = gltf::import(gltf.path).unwrap();
-        let document: &'static gltf::Document = Box::leak(Box::new(document));
-        let images: &'static Vec<Data> = Box::leak(Box::new(images));
-        let materials: &'static Vec<gltf::Material> =
+        let document: &'scene gltf::Document = Box::leak(Box::new(document));
+        let images: &'scene Vec<Data> = Box::leak(Box::new(images));
+        let materials: &'scene Vec<gltf::Material> =
             Box::leak(Box::new(document.materials().collect()));
 
         for scene in document.scenes() {
@@ -105,12 +105,12 @@ impl<'scene> HitableTrait for GLTF<'scene> {
     }
 }
 
-fn parse_node(
+fn parse_node<'scene>(
     node: &Node,
-    objects: &mut Vec<Hitable>,
+    objects: &mut Vec<Hitable<'scene>>,
     buffers: &Vec<gltf::buffer::Data>,
-    materials: &'static Vec<gltf::Material>,
-    images: &'static Vec<Data>,
+    materials: &'scene Vec<gltf::Material>,
+    images: &'scene Vec<Data>,
 ) {
     // Handle direct meshes
     if let Some(mesh) = node.mesh() {
@@ -122,12 +122,12 @@ fn parse_node(
     }
 }
 
-fn parse_mesh(
+fn parse_mesh<'scene>(
     mesh: &Mesh,
-    objects: &mut Vec<Hitable>,
+    objects: &mut Vec<Hitable<'scene>>,
     buffers: &[gltf::buffer::Data],
-    materials: &'static [gltf::Material],
-    images: &'static [Data],
+    materials: &'scene [gltf::Material],
+    images: &'scene [Data],
 ) {
     debug!("found mesh");
     for primitive in mesh.primitives() {
@@ -196,7 +196,7 @@ fn parse_mesh(
                         });
 
                         // TODO: don't leak memory
-                        let material: &'static Material = Box::leak(Box::new(Material::GLTF(
+                        let material: &'scene Material = Box::leak(Box::new(Material::GLTF(
                             GLTFMaterial::new(material, tex_coords, normals, tangents, images),
                         )));
 

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use rand::rngs::SmallRng;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [`Sphere`](super::Sphere). Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
 pub struct MovingSphereInit<'scene> {
@@ -25,7 +25,7 @@ pub struct MovingSphereInit<'scene> {
     pub material: Material<'scene>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
 pub struct MovingSphere<'scene> {

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -66,7 +66,7 @@ impl<'scene> MovingSphere<'scene> {
             center_1 + Vec3::new(radius, radius, radius),
         );
 
-        let aabb = AABB::surrounding_box(box0, box1);
+        let aabb = AABB::surrounding_box(&box0, &box1);
 
         MovingSphere {
             center_0,
@@ -158,8 +158,8 @@ impl<'scene> HitableTrait for MovingSphere<'scene> {
 
     /// Returns the axis-aligned bounding box of the [`MovingSphere`] object. This is the maximum possible bounding box of the entire span of the movement of the sphere, calculated from the two center positions and the radius.
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     fn pdf_value(&self, _origin: Vec3, _vector: Vec3, _time: Float, _rng: &mut SmallRng) -> Float {

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -13,7 +13,7 @@ use rand::rngs::SmallRng;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [`Sphere`](super::Sphere). Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct MovingSphereInit<'scene> {
+pub struct MovingSphereInit {
     /// Center point of the sphere at time_0
     pub center_0: Vec3,
     /// Center point of the sphere at time_1
@@ -22,11 +22,10 @@ pub struct MovingSphereInit<'scene> {
     pub radius: Float,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material of the sphere.
-    pub material: Material<'scene>,
+    pub material: Material,
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
 pub struct MovingSphere<'scene> {
     /// Center point of the sphere at time_0
@@ -40,8 +39,7 @@ pub struct MovingSphere<'scene> {
     /// Radius of the sphere
     pub radius: Float,
     /// Material of the sphere
-    #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material<'scene>,
+    pub material: &'scene Material,
     /// Axis-aligned bounding box
     pub aabb: AABB,
 }
@@ -55,7 +53,7 @@ impl<'scene> MovingSphere<'scene> {
         time_0: Float,
         time_1: Float,
         radius: Float,
-        material: Material<'scene>,
+        material: &'scene Material,
     ) -> Self {
         let box0: AABB = AABB::new_from_coords(
             center_0 - Vec3::new(radius, radius, radius),
@@ -128,7 +126,7 @@ impl<'scene> HitableTrait for MovingSphere<'scene> {
                     normal: outward_normal,
                     u,
                     v,
-                    material: &self.material,
+                    material: self.material,
                     front_face: false, // TODO: fix having to declare it before calling face_normal
                 };
                 record.set_face_normal(ray, outward_normal);
@@ -146,7 +144,7 @@ impl<'scene> HitableTrait for MovingSphere<'scene> {
                     normal: outward_normal,
                     u,
                     v,
-                    material: &self.material,
+                    material: self.material,
                     front_face: false, // TODO: fix having to declare it before calling face_normal
                 };
                 record.set_face_normal(ray, outward_normal);

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -13,7 +13,7 @@ use rand::rngs::SmallRng;
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [`Sphere`](super::Sphere). Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct MovingSphereInit {
+pub struct MovingSphereInit<'scene> {
     /// Center point of the sphere at time_0
     pub center_0: Vec3,
     /// Center point of the sphere at time_1
@@ -22,13 +22,13 @@ pub struct MovingSphereInit {
     pub radius: Float,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material of the sphere.
-    pub material: Material,
+    pub material: Material<'scene>,
 }
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
-pub struct MovingSphere {
+pub struct MovingSphere<'scene> {
     /// Center point of the sphere at time_0
     pub center_0: Vec3,
     /// Center point of the sphere at time_1
@@ -41,12 +41,12 @@ pub struct MovingSphere {
     pub radius: Float,
     /// Material of the sphere
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material,
+    pub material: Material<'scene>,
     /// Axis-aligned bounding box
     pub aabb: AABB,
 }
 
-impl MovingSphere {
+impl<'scene> MovingSphere<'scene> {
     /// Creates a new `MovingSphere` object. See the struct documentation for more information: [`MovingSphere`].
     #[must_use]
     pub fn new(
@@ -55,7 +55,7 @@ impl MovingSphere {
         time_0: Float,
         time_1: Float,
         radius: Float,
-        material: Material,
+        material: Material<'scene>,
     ) -> Self {
         let box0: AABB = AABB::new_from_coords(
             center_0 - Vec3::new(radius, radius, radius),
@@ -99,7 +99,7 @@ impl MovingSphere {
     }
 }
 
-impl HitableTrait for MovingSphere {
+impl<'scene> HitableTrait for MovingSphere<'scene> {
     /// Hit method for the [`MovingSphere`] object. First gets the interpolated center position at the given time, then follows the implementation of [Sphere](crate::objects::Sphere) object's hit method.
     #[must_use]
     fn hit(

--- a/clovers/src/objects/quad.rs
+++ b/clovers/src/objects/quad.rs
@@ -11,7 +11,7 @@ use rand::rngs::SmallRng;
 use rand::Rng;
 
 /// Initialization structure for a Quad object.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct QuadInit<'scene> {
     /// Corner point
@@ -26,8 +26,7 @@ pub struct QuadInit<'scene> {
 }
 
 /// Quadrilateral shape. This can be an arbitrary parallelogram, not just a rectangle.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Quad<'scene> {
     /// Corner point
     pub q: Vec3,
@@ -36,8 +35,7 @@ pub struct Quad<'scene> {
     /// Vector describing the v side
     pub v: Vec3,
     /// Material of the surface
-    #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material<'scene>,
+    pub material: &'scene Material<'scene>,
     /// Area of the surface
     pub area: Float,
     /// Normal vector of the surface
@@ -53,7 +51,7 @@ pub struct Quad<'scene> {
 impl<'scene> Quad<'scene> {
     /// Creates a new quad
     #[must_use]
-    pub fn new(q: Vec3, u: Vec3, v: Vec3, material: Material) -> Quad {
+    pub fn new(q: Vec3, u: Vec3, v: Vec3, material: &'scene Material) -> Quad<'scene> {
         let n: Vec3 = u.cross(&v);
         let normal: Vec3 = n.normalize();
         // TODO: what is this?
@@ -122,7 +120,7 @@ impl<'scene> HitableTrait for Quad<'scene> {
             normal,
             u: alpha,
             v: beta,
-            material: &self.material,
+            material: self.material,
             front_face,
         })
     }

--- a/clovers/src/objects/quad.rs
+++ b/clovers/src/objects/quad.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 /// Initialization structure for a Quad object.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct QuadInit {
+pub struct QuadInit<'scene> {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -22,13 +22,13 @@ pub struct QuadInit {
     pub v: Vec3,
     /// Material of the surface
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material,
+    pub material: Material<'scene>,
 }
 
 /// Quadrilateral shape. This can be an arbitrary parallelogram, not just a rectangle.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct Quad {
+pub struct Quad<'scene> {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -37,7 +37,7 @@ pub struct Quad {
     pub v: Vec3,
     /// Material of the surface
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material,
+    pub material: Material<'scene>,
     /// Area of the surface
     pub area: Float,
     /// Normal vector of the surface
@@ -50,7 +50,7 @@ pub struct Quad {
     pub aabb: AABB,
 }
 
-impl Quad {
+impl<'scene> Quad<'scene> {
     /// Creates a new quad
     #[must_use]
     pub fn new(q: Vec3, u: Vec3, v: Vec3, material: Material) -> Quad {
@@ -78,7 +78,7 @@ impl Quad {
     }
 }
 
-impl HitableTrait for Quad {
+impl<'scene> HitableTrait for Quad<'scene> {
     /// Hit method for the quad rectangle
     #[must_use]
     fn hit(

--- a/clovers/src/objects/quad.rs
+++ b/clovers/src/objects/quad.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 /// Initialization structure for a Quad object.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct QuadInit<'scene> {
+pub struct QuadInit {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -22,7 +22,7 @@ pub struct QuadInit<'scene> {
     pub v: Vec3,
     /// Material of the surface
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material<'scene>,
+    pub material: Material,
 }
 
 /// Quadrilateral shape. This can be an arbitrary parallelogram, not just a rectangle.
@@ -35,7 +35,7 @@ pub struct Quad<'scene> {
     /// Vector describing the v side
     pub v: Vec3,
     /// Material of the surface
-    pub material: &'scene Material<'scene>,
+    pub material: &'scene Material,
     /// Area of the surface
     pub area: Float,
     /// Normal vector of the surface

--- a/clovers/src/objects/quad.rs
+++ b/clovers/src/objects/quad.rs
@@ -127,8 +127,8 @@ impl<'scene> HitableTrait for Quad<'scene> {
 
     /// Returns the bounding box of the quad
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value? // TODO: understand & explain

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -13,9 +13,9 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `RotateInit` structure describes the necessary data for constructing a [`RotateY`]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct RotateInit<'scene> {
+pub struct RotateInit {
     /// The encased [Object] to rotate
-    pub object: Box<Object<'scene>>,
+    pub object: Box<Object>,
     /// Angle to rotate the object, in degrees
     pub angle: Float,
 }

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -39,7 +39,7 @@ impl<'scene> RotateY<'scene> {
         let radians: Float = angle.to_radians();
         let sin_theta: Float = radians.sin();
         let cos_theta: Float = radians.cos();
-        let bounding_box: Option<AABB> = object.bounding_box(time_0, time_1);
+        let bounding_box: Option<&AABB> = object.bounding_box(time_0, time_1);
 
         // Does our object have a bounding box?
         let Some(bbox) = bounding_box else {
@@ -149,8 +149,8 @@ impl<'scene> HitableTrait for RotateY<'scene> {
 
     /// Bounding box method for the [`RotateY`] object. Finds the axis-aligned bounding box [AABB] for the encased [Object] after adjusting for rotation.
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        self.aabb
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        self.aabb.as_ref()
     }
 
     fn pdf_value(&self, _origin: Vec3, _vector: Vec3, _time: Float, _rng: &mut SmallRng) -> Float {

--- a/clovers/src/objects/rotate.rs
+++ b/clovers/src/objects/rotate.rs
@@ -13,26 +13,26 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `RotateInit` structure describes the necessary data for constructing a [`RotateY`]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct RotateInit {
+pub struct RotateInit<'scene> {
     /// The encased [Object] to rotate
-    pub object: Box<Object>,
+    pub object: Box<Object<'scene>>,
     /// Angle to rotate the object, in degrees
     pub angle: Float,
 }
 
 #[derive(Debug, Clone)]
 /// `RotateY` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `angle` given.
-pub struct RotateY {
-    object: Box<Hitable>,
+pub struct RotateY<'scene> {
+    object: Box<Hitable<'scene>>,
     sin_theta: Float,
     cos_theta: Float,
     aabb: Option<AABB>,
 }
 
-impl RotateY {
+impl<'scene> RotateY<'scene> {
     /// Creates a new `RotateY` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `angle` given.
     #[must_use]
-    pub fn new(object: Box<Hitable>, angle: Float) -> Self {
+    pub fn new(object: Box<Hitable<'scene>>, angle: Float) -> Self {
         // TODO: add proper time support
         let time_0: Float = 0.0;
         let time_1: Float = 1.0;
@@ -94,7 +94,7 @@ impl RotateY {
     }
 }
 
-impl HitableTrait for RotateY {
+impl<'scene> HitableTrait for RotateY<'scene> {
     /// Hit method for the [`RotateY`] object. Finds the rotation-adjusted [`HitRecord`] for the possible intersection of the [Ray] with the encased [Object].
     #[must_use]
     fn hit(

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -13,30 +13,30 @@ use rand::{rngs::SmallRng, Rng};
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [Sphere]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct SphereInit {
+pub struct SphereInit<'scene> {
     /// Center of the sphere.
     pub center: Vec3,
     /// Radius of the sphere.
     pub radius: Float,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material of the sphere.
-    pub material: Material,
+    pub material: Material<'scene>,
 }
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A sphere object.
-pub struct Sphere {
+pub struct Sphere<'scene> {
     center: Vec3,
     radius: Float,
-    material: Material,
+    material: Material<'scene>,
     aabb: AABB,
 }
 
-impl Sphere {
+impl<'scene> Sphere<'scene> {
     /// Creates a new `Sphere` object with the given center, radius and material.
     #[must_use]
-    pub fn new(center: Vec3, radius: Float, material: Material) -> Self {
+    pub fn new(center: Vec3, radius: Float, material: Material<'scene>) -> Self {
         let aabb = AABB::new_from_coords(
             center - Vec3::new(radius, radius, radius),
             center + Vec3::new(radius, radius, radius),
@@ -61,7 +61,7 @@ impl Sphere {
     }
 }
 
-impl HitableTrait for Sphere {
+impl<'scene> HitableTrait for Sphere<'scene> {
     /// Hit method for the [Sphere] object. Returns a [`HitRecord`] if the given [Ray] intersects with the sphere at the given distance interval.
     #[must_use]
     fn hit(

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -13,30 +13,29 @@ use rand::{rngs::SmallRng, Rng};
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [Sphere]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct SphereInit<'scene> {
+pub struct SphereInit {
     /// Center of the sphere.
     pub center: Vec3,
     /// Radius of the sphere.
     pub radius: Float,
     #[cfg_attr(feature = "serde-derive", serde(default))]
     /// Material of the sphere.
-    pub material: Material<'scene>,
+    pub material: Material,
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A sphere object.
 pub struct Sphere<'scene> {
     center: Vec3,
     radius: Float,
-    material: Material<'scene>,
+    material: &'scene Material,
     aabb: AABB,
 }
 
 impl<'scene> Sphere<'scene> {
     /// Creates a new `Sphere` object with the given center, radius and material.
     #[must_use]
-    pub fn new(center: Vec3, radius: Float, material: Material<'scene>) -> Self {
+    pub fn new(center: Vec3, radius: Float, material: &'scene Material) -> Self {
         let aabb = AABB::new_from_coords(
             center - Vec3::new(radius, radius, radius),
             center + Vec3::new(radius, radius, radius),
@@ -91,7 +90,7 @@ impl<'scene> HitableTrait for Sphere<'scene> {
                     normal: outward_normal,
                     u,
                     v,
-                    material: &self.material,
+                    material: self.material,
                     front_face: false, // TODO: fix having to declare it before calling face_normal
                 };
                 record.set_face_normal(ray, outward_normal);
@@ -109,7 +108,7 @@ impl<'scene> HitableTrait for Sphere<'scene> {
                     normal: outward_normal,
                     u,
                     v,
-                    material: &self.material,
+                    material: self.material,
                     front_face: false, // TODO: fix having to declare it before calling face_normal
                 };
                 record.set_face_normal(ray, outward_normal);

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -121,8 +121,8 @@ impl<'scene> HitableTrait for Sphere<'scene> {
 
     /// Returns the axis-aligned bounding box [AABB] for the sphere.
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns the probability density function for the sphere? TODO: what does this do again and how

--- a/clovers/src/objects/sphere.rs
+++ b/clovers/src/objects/sphere.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use rand::{rngs::SmallRng, Rng};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `SphereInit` structure describes the necessary data for constructing a [Sphere]. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
 pub struct SphereInit<'scene> {
@@ -23,7 +23,7 @@ pub struct SphereInit<'scene> {
     pub material: Material<'scene>,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A sphere object.
 pub struct Sphere<'scene> {

--- a/clovers/src/objects/stl.rs
+++ b/clovers/src/objects/stl.rs
@@ -22,7 +22,7 @@ pub struct STL<'scene> {
     /// Bounding Volume Hierarchy tree for the object
     pub bvhnode: BVHNode<'scene>,
     /// Material for the object
-    pub material: Material<'scene>,
+    pub material: &'scene Material<'scene>,
     /// Axis-aligned bounding box of the object
     pub aabb: AABB,
 }
@@ -31,7 +31,7 @@ impl<'scene> STL<'scene> {
     #[must_use]
     /// Create a new STL object with the given initialization parameters.
     pub fn new(stl_init: &'scene STLInit<'scene>, time_0: Float, time_1: Float) -> Self {
-        let material = stl_init.material;
+        let material = &stl_init.material;
         let triangles: Vec<Hitable> = stl_init.into();
         let bvhnode = BVHNode::from_list(triangles, time_0, time_1);
         // TODO: remove unwrap

--- a/clovers/src/objects/stl.rs
+++ b/clovers/src/objects/stl.rs
@@ -22,7 +22,7 @@ pub struct STL<'scene> {
     /// Bounding Volume Hierarchy tree for the object
     pub bvhnode: BVHNode<'scene>,
     /// Material for the object
-    pub material: &'scene Material<'scene>,
+    pub material: &'scene Material,
     /// Axis-aligned bounding box of the object
     pub aabb: AABB,
 }
@@ -30,7 +30,7 @@ pub struct STL<'scene> {
 impl<'scene> STL<'scene> {
     #[must_use]
     /// Create a new STL object with the given initialization parameters.
-    pub fn new(stl_init: &'scene STLInit<'scene>, time_0: Float, time_1: Float) -> Self {
+    pub fn new(stl_init: &'scene STLInit, time_0: Float, time_1: Float) -> Self {
         let material = &stl_init.material;
         let triangles: Vec<Hitable> = stl_init.into();
         let bvhnode = BVHNode::from_list(triangles, time_0, time_1);
@@ -80,12 +80,12 @@ impl<'scene> HitableTrait for STL<'scene> {
 /// STL structure. This gets converted into an internal representation using [Triangles](crate::objects::Triangle)
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct STLInit<'scene> {
+pub struct STLInit {
     /// Path of the .stl file
     pub path: String,
     /// Material to use for the .stl object
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material<'scene>,
+    pub material: Material,
     /// Scaling factor for the object
     pub scale: Float,
     /// Location of the object in the rendered scene
@@ -94,9 +94,9 @@ pub struct STLInit<'scene> {
     pub rotation: Vec3,
 }
 
-impl<'scene> From<&'scene STLInit<'scene>> for Vec<Hitable<'scene>> {
+impl<'scene> From<&'scene STLInit> for Vec<Hitable<'scene>> {
     #[must_use]
-    fn from(stl_init: &'scene STLInit<'scene>) -> Self {
+    fn from(stl_init: &'scene STLInit) -> Self {
         // TODO: error handling!
         let mut file = OpenOptions::new()
             .read(true)

--- a/clovers/src/objects/stl.rs
+++ b/clovers/src/objects/stl.rs
@@ -35,7 +35,7 @@ impl<'scene> STL<'scene> {
         let triangles: Vec<Hitable> = stl_init.into();
         let bvhnode = BVHNode::from_list(triangles, time_0, time_1);
         // TODO: remove unwrap
-        let aabb = bvhnode.bounding_box(time_0, time_1).unwrap();
+        let aabb = bvhnode.bounding_box(time_0, time_1).unwrap().clone();
 
         STL {
             bvhnode,
@@ -60,8 +60,8 @@ impl<'scene> HitableTrait for STL<'scene> {
 
     /// Return the axis-aligned bounding box for the object
     #[must_use]
-    fn bounding_box(&self, _t0: f32, _t1: f32) -> Option<AABB> {
-        Some(self.aabb)
+    fn bounding_box(&self, _t0: f32, _t1: f32) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value based on the object

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -25,13 +25,20 @@ pub struct TranslateInit<'scene> {
 pub struct Translate<'scene> {
     object: Box<Hitable<'scene>>,
     offset: Vec3,
+    aabb: AABB,
 }
 
 impl<'scene> Translate<'scene> {
     /// Creates a new `Translate` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `offset` given.
     #[must_use]
     pub fn new(object: Box<Hitable<'scene>>, offset: Vec3) -> Self {
-        Translate { object, offset }
+        // TODO: time
+        let aabb = object.bounding_box(0.0, 1.0).unwrap().clone() + offset;
+        Translate {
+            object,
+            offset,
+            aabb,
+        }
     }
 }
 
@@ -61,10 +68,8 @@ impl<'scene> HitableTrait for Translate<'scene> {
 
     /// Bounding box method for the [Translate] object. Finds the axis-aligned bounding box [AABB] for the encased [Object] after adjusting for translation.
     #[must_use]
-    fn bounding_box(&self, t0: Float, t1: Float) -> Option<AABB> {
-        // TODO: cached into self.aabb ?
-        let aabb = self.object.bounding_box(t0, t1);
-        aabb.map(|b| b + self.offset)
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value based on the inner object

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -13,9 +13,9 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `TranslateInit` structure describes the necessary data for constructing a [Translate] object. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct TranslateInit<'scene> {
+pub struct TranslateInit {
     /// The encased [Object] to translate i.e. move
-    pub object: Box<Object<'scene>>,
+    pub object: Box<Object>,
     /// The vector describing the movement of the object
     pub offset: Vec3,
 }

--- a/clovers/src/objects/translate.rs
+++ b/clovers/src/objects/translate.rs
@@ -13,29 +13,29 @@ use super::Object;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// `TranslateInit` structure describes the necessary data for constructing a [Translate] object. Used with [serde] when importing [`SceneFile`](crate::scenes::SceneFile)s.
-pub struct TranslateInit {
+pub struct TranslateInit<'scene> {
     /// The encased [Object] to translate i.e. move
-    pub object: Box<Object>,
+    pub object: Box<Object<'scene>>,
     /// The vector describing the movement of the object
     pub offset: Vec3,
 }
 
 #[derive(Debug, Clone)]
 /// Translate object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `offset` given.
-pub struct Translate {
-    object: Box<Hitable>,
+pub struct Translate<'scene> {
+    object: Box<Hitable<'scene>>,
     offset: Vec3,
 }
 
-impl Translate {
+impl<'scene> Translate<'scene> {
     /// Creates a new `Translate` object. It wraps the given [Object] and has adjusted `hit()` and `bounding_box()` methods based on the `offset` given.
     #[must_use]
-    pub fn new(object: Box<Hitable>, offset: Vec3) -> Self {
+    pub fn new(object: Box<Hitable<'scene>>, offset: Vec3) -> Self {
         Translate { object, offset }
     }
 }
 
-impl HitableTrait for Translate {
+impl<'scene> HitableTrait for Translate<'scene> {
     /// Hit method for the [Translate] object. Finds the translation-adjusted [`HitRecord`] for the possible intersection of the [Ray] with the encased [Object].
     #[must_use]
     fn hit(

--- a/clovers/src/objects/triangle.rs
+++ b/clovers/src/objects/triangle.rs
@@ -12,7 +12,7 @@ use rand::rngs::SmallRng;
 use rand::Rng;
 
 /// Initialization structure for a triangle primitive
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriangleInit<'scene> {
     /// Corner point

--- a/clovers/src/objects/triangle.rs
+++ b/clovers/src/objects/triangle.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 /// Initialization structure for a triangle primitive
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct TriangleInit<'scene> {
+pub struct TriangleInit {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -23,7 +23,7 @@ pub struct TriangleInit<'scene> {
     pub v: Vec3,
     /// Material of the surface
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material<'scene>,
+    pub material: Material,
 }
 
 /// Triangle shape. Heavily based on [Quad](crate::objects::Quad) and may contain inaccuracies
@@ -36,7 +36,7 @@ pub struct Triangle<'scene> {
     /// Vector describing the v side
     pub v: Vec3,
     /// Material of the surface
-    pub material: &'scene Material<'scene>,
+    pub material: &'scene Material,
     /// Area of the surface
     pub area: Float,
     /// Normal vector of the surface

--- a/clovers/src/objects/triangle.rs
+++ b/clovers/src/objects/triangle.rs
@@ -161,10 +161,10 @@ impl<'scene> HitableTrait for Triangle<'scene> {
 
     /// Returns the bounding box of the triangle
     #[must_use]
-    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<AABB> {
+    fn bounding_box(&self, _t0: Float, _t1: Float) -> Option<&AABB> {
         // TODO: this is from quad and not updated!
         // although i guess a triangle's aabb is the same as the quad's aabb in worst case
-        Some(self.aabb)
+        Some(&self.aabb)
     }
 
     /// Returns a probability density function value? // TODO: understand & explain
@@ -253,7 +253,7 @@ mod tests {
             Interval::new(0.0, 0.0).expand(EPSILON_RECT_THICKNESS),
         );
 
-        assert_eq!(aabb, expected_aabb);
+        assert_eq!(aabb, &expected_aabb);
 
         let boxhit = aabb.hit(&ray, time_0, time_1);
         assert!(boxhit);
@@ -299,7 +299,7 @@ mod tests {
             Interval::new(0.0, 0.0).expand(EPSILON_RECT_THICKNESS),
         );
 
-        assert_eq!(aabb, expected_aabb);
+        assert_eq!(aabb, &expected_aabb);
 
         let boxhit = aabb.hit(&ray, time_0, time_1);
         assert!(boxhit);
@@ -345,7 +345,7 @@ mod tests {
             Interval::new(0.0, 0.0).expand(EPSILON_RECT_THICKNESS),
         );
 
-        assert_eq!(aabb, expected_aabb);
+        assert_eq!(aabb, &expected_aabb);
 
         let boxhit = aabb.hit(&ray, time_0, time_1);
         assert!(boxhit);

--- a/clovers/src/objects/triangle.rs
+++ b/clovers/src/objects/triangle.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 /// Initialization structure for a triangle primitive
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
-pub struct TriangleInit {
+pub struct TriangleInit<'scene> {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -23,12 +23,12 @@ pub struct TriangleInit {
     pub v: Vec3,
     /// Material of the surface
     #[cfg_attr(feature = "serde-derive", serde(default))]
-    pub material: Material,
+    pub material: Material<'scene>,
 }
 
 /// Triangle shape. Heavily based on [Quad](crate::objects::Quad) and may contain inaccuracies
-#[derive(Clone, Copy, Debug)]
-pub struct Triangle {
+#[derive(Clone, Debug)]
+pub struct Triangle<'scene> {
     /// Corner point
     pub q: Vec3,
     /// Vector describing the u side
@@ -36,7 +36,7 @@ pub struct Triangle {
     /// Vector describing the v side
     pub v: Vec3,
     /// Material of the surface
-    pub material: &'static Material,
+    pub material: &'scene Material<'scene>,
     /// Area of the surface
     pub area: Float,
     /// Normal vector of the surface
@@ -49,10 +49,10 @@ pub struct Triangle {
     pub aabb: AABB,
 }
 
-impl Triangle {
+impl<'scene> Triangle<'scene> {
     /// Creates a new triangle from a coordinate point and two side vectors relative to the point
     #[must_use]
-    pub fn new(q: Vec3, u: Vec3, v: Vec3, material: &'static Material) -> Triangle {
+    pub fn new(q: Vec3, u: Vec3, v: Vec3, material: &'scene Material) -> Triangle<'scene> {
         let n: Vec3 = u.cross(&v);
         let normal: Vec3 = n.normalize();
         // TODO: what is this?
@@ -96,7 +96,12 @@ impl Triangle {
 
     /// Creates a new triangle from three Cartesian space coordinates
     #[must_use]
-    pub fn from_coordinates(a: Vec3, b: Vec3, c: Vec3, material: &'static Material) -> Triangle {
+    pub fn from_coordinates(
+        a: Vec3,
+        b: Vec3,
+        c: Vec3,
+        material: &'scene Material,
+    ) -> Triangle<'scene> {
         // Coordinate transform: from absolute coordinates to relative coordinates
         let q: Vec3 = a;
         let u: Vec3 = b - q;
@@ -105,7 +110,7 @@ impl Triangle {
     }
 }
 
-impl HitableTrait for Triangle {
+impl<'scene> HitableTrait for Triangle<'scene> {
     /// Hit method for the triangle
     #[must_use]
     fn hit(
@@ -220,14 +225,14 @@ mod tests {
     fn xy_unit_triangle() {
         let time_0 = 0.0;
         let time_1 = 1.0;
-        let material: &'static Material = Box::leak(Box::default());
+        let material = Box::default();
 
         // Unit triangle at origin
         let xy_unit_triangle = Triangle::new(
             Vec3::new(0.0, 0.0, 0.0),
             Vec3::new(1.0, 0.0, 0.0),
             Vec3::new(0.0, 1.0, 0.0),
-            material,
+            &material,
         );
 
         let ray = Ray::new(
@@ -266,14 +271,14 @@ mod tests {
     fn yx_unit_triangle() {
         let time_0 = 0.0;
         let time_1 = 1.0;
-        let material: &'static Material = Box::leak(Box::default());
+        let material = Box::default();
 
         // Unit triangle at origin, u and v coords swapped
         let xy_unit_triangle = Triangle::new(
             Vec3::new(0.0, 0.0, 0.0),
             Vec3::new(0.0, 1.0, 0.0),
             Vec3::new(1.0, 0.0, 0.0),
-            material,
+            &material,
         );
 
         let ray = Ray::new(
@@ -312,14 +317,14 @@ mod tests {
     fn neg_xy_unit_triangle() {
         let time_0 = 0.0;
         let time_1 = 1.0;
-        let material: &'static Material = Box::leak(Box::default());
+        let material: Box<Material> = Box::default();
 
         // Unit triangle at origin, u and v coords swapped
         let neg_xy_unit_triangle = Triangle::new(
             Vec3::new(0.0, 0.0, 0.0),
             Vec3::new(-1.0, 0.0, 0.0),
             Vec3::new(0.0, -1.0, 0.0),
-            material,
+            &material,
         );
 
         let ray = Ray::new(

--- a/clovers/src/pdf.rs
+++ b/clovers/src/pdf.rs
@@ -65,7 +65,7 @@ impl PDFTrait for CosinePDF {
 #[derive(Debug, Clone)]
 pub struct HitablePDF<'scene> {
     origin: Vec3,
-    hitable: &'scene Hitable,
+    hitable: &'scene Hitable<'scene>,
 }
 
 impl<'scene> HitablePDF<'scene> {

--- a/clovers/src/ray.rs
+++ b/clovers/src/ray.rs
@@ -3,7 +3,7 @@
 use crate::{Float, Vec3};
 
 /// A Ray has an origin and a direction, as well as an instant in time it exists in. Motion blur is achieved by creating multiple rays with slightly different times.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Ray {
     /// The origin of the ray.
     pub origin: Vec3,

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -53,18 +53,18 @@ impl<'scene> Scene<'scene> {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A serialized representation of a [Scene].
-pub struct SceneFile<'scene> {
+pub struct SceneFile {
     time_0: Float,
     time_1: Float,
     background_color: Color,
     camera: CameraInit,
-    objects: Vec<Object<'scene>>,
-    priority_objects: Vec<Object<'scene>>,
+    objects: Vec<Object>,
+    priority_objects: Vec<Object>,
 }
 
 /// Initializes a new [Scene] instance by parsing the contents of a [`SceneFile`] structure and then using those details to construct the [Scene].
 #[must_use]
-pub fn initialize(scene_file: SceneFile, width: u32, height: u32) -> Scene {
+pub fn initialize<'scene>(scene_file: SceneFile, width: u32, height: u32) -> Scene<'scene> {
     let time_0 = scene_file.time_0;
     let time_1 = scene_file.time_1;
     let background_color = scene_file.background_color;
@@ -98,7 +98,7 @@ pub fn initialize(scene_file: SceneFile, width: u32, height: u32) -> Scene {
 }
 
 #[must_use]
-fn objects_to_hitables(objects: Vec<Object>) -> Vec<Hitable> {
+fn objects_to_hitables<'scene>(objects: Vec<Object>) -> Vec<Hitable<'scene>> {
     let mut hitables = Vec::new();
     for obj in objects {
         hitables.push(obj.into());

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -14,28 +14,28 @@ use tracing::info;
 
 #[derive(Debug)]
 /// A representation of the scene that is being rendered.
-pub struct Scene {
+pub struct Scene<'scene> {
     /// Bounding-volume hierarchy of [Hitable] objects in the scene. This could, as currently written, be any [Hitable] - in practice, we place the root of the [BVHNode](crate::bvhnode::BVHNode) tree here.
-    pub objects: BVHNode,
+    pub objects: BVHNode<'scene>,
     /// The camera object used for rendering the scene.
     pub camera: Camera,
     /// The background color to use when the rays do not hit anything in the scene.
     pub background_color: Color, // TODO: make into Texture or something?
     /// A [BVHNode](crate::bvhnode::BVHNode) tree of prioritized objects - e.g. glass items or lights - that affect the biased sampling of the scene. Wrapped into a [Hitable] for convenience reasons (see various PDF functions).
-    pub priority_objects: Hitable,
+    pub priority_objects: Hitable<'scene>,
 }
 
-impl Scene {
+impl<'scene> Scene<'scene> {
     /// Creates a new [Scene] with the given parameters.
     #[must_use]
     pub fn new(
         time_0: Float,
         time_1: Float,
         camera: Camera,
-        objects: Vec<Hitable>,
-        priority_objects: Vec<Hitable>,
+        objects: Vec<Hitable<'scene>>,
+        priority_objects: Vec<Hitable<'scene>>,
         background_color: Color,
-    ) -> Scene {
+    ) -> Scene<'scene> {
         Scene {
             objects: BVHNode::from_list(objects, time_0, time_1),
             camera,
@@ -53,13 +53,13 @@ impl Scene {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A serialized representation of a [Scene].
-pub struct SceneFile {
+pub struct SceneFile<'scene> {
     time_0: Float,
     time_1: Float,
     background_color: Color,
     camera: CameraInit,
-    objects: Vec<Object>,
-    priority_objects: Vec<Object>,
+    objects: Vec<Object<'scene>>,
+    priority_objects: Vec<Object<'scene>>,
 }
 
 /// Initializes a new [Scene] instance by parsing the contents of a [`SceneFile`] structure and then using those details to construct the [Scene].

--- a/clovers/src/textures.rs
+++ b/clovers/src/textures.rs
@@ -12,7 +12,7 @@ pub use surface_checker::*;
 use crate::{color::Color, Float, Vec3};
 
 #[enum_dispatch(TextureTrait)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A texture enum.
 #[cfg_attr(feature = "serde-derive", serde(tag = "kind"))]

--- a/clovers/src/textures/solid_color.rs
+++ b/clovers/src/textures/solid_color.rs
@@ -4,7 +4,7 @@ use crate::{color::Color, Float, Vec3};
 
 use super::TextureTrait;
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A solid color texture. Simplest possible [Texture](crate::textures::Texture): returns a solid color at any surface coordinate or spatial position.
 pub struct SolidColor {

--- a/clovers/src/textures/spatial_checker.rs
+++ b/clovers/src/textures/spatial_checker.rs
@@ -5,7 +5,7 @@
 use super::TextureTrait;
 use crate::{color::Color, Float, Vec3, PI};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on spatial 3D texturing.
 pub struct SpatialChecker {

--- a/clovers/src/textures/surface_checker.rs
+++ b/clovers/src/textures/surface_checker.rs
@@ -6,7 +6,7 @@ use crate::Float;
 use crate::Vec3;
 use crate::PI;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde-derive", derive(serde::Serialize, serde::Deserialize))]
 /// A standard checkered texture based on 2D surface UV coordinates.
 pub struct SurfaceChecker {


### PR DESCRIPTION
Making all the various `Hitable` structs to contain a reference `&Material` instead of owning their own `Copy` of a `Material`.

Cons: This sadly requires spamming quite a lot of `<'scene>` lifetimes around
Pros: This reduces the memory usage on some scenes quite significantly - directly proportional to the amount of triangles using a shared material

this branch
```
just cli -i scenes/dragon.json  714.97s user 3.72s system 713% cpu 1:40.78 total
64M reserved

just cli -i scenes/gltf_scifi_helmet.json  535.42s user 2.65s system 736% cpu 1:13.04 total
122M reserved
```
main 305d52388fe2067bf93f7fdc4a804cf00e8eb3bc
```
just cli -i scenes/dragon.json  728.58s user 5.51s system 733% cpu 1:40.13 total
150M reserved

just cli -i scenes/gltf_scifi_helmet.json  544.08s user 4.35s system 722% cpu 1:15.90 total
132M reserved
```

---

There's still a lot of additional work to do in later PRs - e.g.
- removing the last uses of `Box::leak`
- having a separate materials list in the scene format and objects having references to it
- hopefully cleaning up the code a bit, it is rather messy right now