### PR TITLE
feat: blue noise sampling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build release
         run: cargo build --release --verbose
       - name: Render all test images
-        run: just all-scenes
+        run: just all-scenes --samples 1
       - uses: actions/upload-artifact@v3
         with:
           name: renders

--- a/Justfile
+++ b/Justfile
@@ -32,8 +32,8 @@ test:
   cargo nextest run --cargo-quiet
 
 # Run all benchmarks
-bench:
-  cargo bench --quiet
+bench *ARGS:
+  cargo bench --quiet {{ARGS}}
 
 # Verify no_std compatibility
 nostd:

--- a/Justfile
+++ b/Justfile
@@ -15,11 +15,11 @@ scene:
   cargo run --bin clovers-cli --release -- --input scenes/scene.json -w 1920 -h 1080
 
 # Render all the test scenes available in the repository
-all-scenes spp="1":
+all-scenes *ARGS:
   DATE=$(date -u +%s); \
   mkdir -p renders/$DATE; \
   for scene in $(ls scenes/ |grep json); \
-  do just cli -s {{spp}} --input scenes/$scene --output renders/$DATE/${scene%.json}.png; \
+  do just cli --input scenes/$scene --output renders/$DATE/${scene%.json}.png {{ARGS}}; \
   done;
 
 # Profiling helper

--- a/Justfile
+++ b/Justfile
@@ -15,11 +15,11 @@ scene:
   cargo run --bin clovers-cli --release -- --input scenes/scene.json -w 1920 -h 1080
 
 # Render all the test scenes available in the repository
-all-scenes:
+all-scenes spp="1":
   DATE=$(date -u +%s); \
   mkdir -p renders/$DATE; \
   for scene in $(ls scenes/ |grep json); \
-  do just cli -s 1 --input scenes/$scene --output renders/$DATE/${scene%.json}.png; \
+  do just cli -s {{spp}} --input scenes/$scene --output renders/$DATE/${scene%.json}.png; \
   done;
 
 # Profiling helper

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Currently, this project is highly experimental. Things change all the time.
 
-- `clovers/` contains the library
-- `clovers-cli/` contains the CLI application
+- `clovers/` contains the core library and types
+- `clovers-cli/` contains the CLI application & runtime
 
 The automatically built documentation is hosted at <https://walther.github.io/clovers/clovers/>.
 
@@ -43,3 +43,4 @@ Making this renderer would not have been possible without the availability of an
 - [Physically Meaningful Rendering using Tristimulus Colours](https://doi.org/10.1111/cgf.12676)
 - [Hero Wavelength Spectral Sampling](https://doi.org/10.1111/cgf.12419)
 - [How to interpret the sRGB color space](https://color.org/chardata/rgb/sRGB.pdf)
+- [Physically Based Rendering: From Theory To Implementation. 4ed](https://pbr-book.org/)

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -31,6 +31,7 @@ img-parts = "0.3.0"
 indicatif = { version = "0.17.8", features = [
   "rayon",
 ], default-features = false }
+nalgebra = { version = "0.32.4" }
 palette = { version = "0.7.5", features = ["serializing"] }
 paste = { version = "1.0.14" }
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -9,9 +9,8 @@ name = "clovers-cli"
 path = "src/main.rs"
 
 [lib]
-# For testing purposes
-name = "clovers_draw_cpu"
-path = "src/draw_cpu.rs"
+name = "clovers_runtime"
+path = "src/lib.rs"
 
 [dependencies]
 # Internal
@@ -23,6 +22,7 @@ clovers = { path = "../clovers", features = [
 ], default-features = false }
 
 # External
+blue-noise-sampler = "0.1.0"
 clap = { version = "4.5.1", features = ["std", "derive"] }
 human_format = "1.1.0"
 humantime = "2.1.0"
@@ -32,6 +32,7 @@ indicatif = { version = "0.17.8", features = [
   "rayon",
 ], default-features = false }
 palette = { version = "0.7.5", features = ["serializing"] }
+paste = { version = "1.0.14" }
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }
 rayon = "1.9.0"
 serde = { version = "1.0.197", features = ["derive"], default-features = false }

--- a/clovers-cli/Cargo.toml
+++ b/clovers-cli/Cargo.toml
@@ -23,7 +23,7 @@ clovers = { path = "../clovers", features = [
 
 # External
 blue-noise-sampler = "0.1.0"
-clap = { version = "4.5.1", features = ["std", "derive"] }
+clap = { version = "4.5.4", features = ["std", "derive"] }
 human_format = "1.1.0"
 humantime = "2.1.0"
 image = { version = "0.24.9", features = ["png"], default-features = false }
@@ -35,7 +35,7 @@ nalgebra = { version = "0.32.4" }
 palette = { version = "0.7.5", features = ["serializing"] }
 paste = { version = "1.0.14" }
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }
-rayon = "1.9.0"
+rayon = "1.10.0"
 serde = { version = "1.0.197", features = ["derive"], default-features = false }
 serde_json = { version = "1.0", features = ["alloc"], default-features = false }
 time = { version = "0.3.34", default-features = false }

--- a/clovers-cli/benches/draw_cpu.rs
+++ b/clovers-cli/benches/draw_cpu.rs
@@ -1,6 +1,7 @@
 use clovers::scenes::{initialize, Scene, SceneFile};
 use clovers::RenderOpts;
-use clovers_draw_cpu::draw;
+use clovers_runtime::draw_cpu::draw;
+use clovers_runtime::sampler::Sampler;
 use divan::{black_box, AllocProfiler};
 
 #[global_allocator]
@@ -26,7 +27,7 @@ fn draw_cornell(bencher: divan::Bencher) {
     bencher
         .with_inputs(get_cornell)
         .counter(1u32)
-        .bench_values(|scene| black_box(draw(OPTS, &scene)))
+        .bench_values(|scene| black_box(draw(OPTS, &scene, Sampler::Random)))
 }
 
 fn get_cornell<'scene>() -> Scene<'scene> {

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -16,7 +16,7 @@ use crate::colorize::colorize;
 use crate::normals::normal_map;
 use crate::sampler::blue::BlueSampler;
 use crate::sampler::random::RandomSampler;
-use crate::sampler::{Sample, Sampler, SamplerTrait};
+use crate::sampler::{Randomness, Sampler, SamplerTrait};
 
 /// The main drawing function, returns a `Vec<Srgb>` as a pixelbuffer.
 pub fn draw(opts: RenderOpts, scene: &Scene, sampler: Sampler) -> Vec<Srgb<u8>> {
@@ -67,7 +67,7 @@ fn render_pixel(
     let max_depth = opts.max_depth;
     let mut pixel_color: Xyz<E> = Xyz::new(0.0, 0.0, 0.0);
     for sample in 0..opts.samples {
-        let Sample {
+        let Randomness {
             pixel_offset,
             lens_offset,
             time,

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -1,8 +1,8 @@
+//! An opinionated method for drawing a scene using the CPU for rendering.
+
 use clovers::wavelength::random_wavelength;
 use clovers::Vec2;
-use clovers::{
-    colorize::colorize, normals::normal_map, ray::Ray, scenes::Scene, Float, RenderOpts,
-};
+use clovers::{ray::Ray, scenes::Scene, Float, RenderOpts};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use palette::chromatic_adaptation::AdaptInto;
 use palette::convert::IntoColorUnclamped;
@@ -12,6 +12,8 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
 
+use crate::colorize::colorize;
+use crate::normals::normal_map;
 use crate::sampler::blue::BlueSampler;
 use crate::sampler::random::RandomSampler;
 use crate::sampler::{Sample, Sampler, SamplerTrait};
@@ -79,7 +81,7 @@ fn render_pixel(
         let ray: Ray = scene
             .camera
             .get_ray(pixel_uv, lens_offset, time, wavelength);
-        let sample_color: Xyz<E> = colorize(&ray, scene, 0, max_depth, rng);
+        let sample_color: Xyz<E> = colorize(&ray, scene, 0, max_depth, rng, sampler);
         if sample_color.x.is_finite() && sample_color.y.is_finite() && sample_color.z.is_finite() {
             pixel_color += sample_color;
         }

--- a/clovers-cli/src/draw_cpu.rs
+++ b/clovers-cli/src/draw_cpu.rs
@@ -1,3 +1,5 @@
+use clovers::wavelength::random_wavelength;
+use clovers::Vec2;
 use clovers::{
     colorize::colorize, normals::normal_map, ray::Ray, scenes::Scene, Float, RenderOpts,
 };
@@ -10,8 +12,12 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
 
+use crate::sampler::blue::BlueSampler;
+use crate::sampler::random::RandomSampler;
+use crate::sampler::{Sample, Sampler, SamplerTrait};
+
 /// The main drawing function, returns a `Vec<Srgb>` as a pixelbuffer.
-pub fn draw(opts: RenderOpts, scene: &Scene) -> Vec<Srgb<u8>> {
+pub fn draw(opts: RenderOpts, scene: &Scene, sampler: Sampler) -> Vec<Srgb<u8>> {
     let width = opts.width as usize;
     let height = opts.height as usize;
     let bar = progress_bar(&opts);
@@ -19,14 +25,21 @@ pub fn draw(opts: RenderOpts, scene: &Scene) -> Vec<Srgb<u8>> {
     let pixelbuffer: Vec<Srgb<u8>> = (0..height)
         .into_par_iter()
         .map(|row_index| {
+            let mut sampler_rng = SmallRng::from_entropy();
+            let mut sampler: Box<dyn SamplerTrait> = match sampler {
+                Sampler::Blue => Box::new(BlueSampler::new(&opts)),
+                Sampler::Random => Box::new(RandomSampler::new(&mut sampler_rng)),
+            };
+
             let mut rng = SmallRng::from_entropy();
             let mut row = Vec::with_capacity(width);
+
             for index in 0..width {
                 let index = index + row_index * width;
                 if opts.normalmap {
                     row.push(render_pixel_normalmap(scene, &opts, index, &mut rng));
                 } else {
-                    row.push(render_pixel(scene, &opts, index, &mut rng));
+                    row.push(render_pixel(scene, &opts, index, &mut rng, &mut *sampler));
                 }
             }
             bar.inc(1);
@@ -39,16 +52,40 @@ pub fn draw(opts: RenderOpts, scene: &Scene) -> Vec<Srgb<u8>> {
 }
 
 // Render a single pixel, including possible multisampling
-fn render_pixel(scene: &Scene, opts: &RenderOpts, index: usize, rng: &mut SmallRng) -> Srgb<u8> {
+fn render_pixel(
+    scene: &Scene,
+    opts: &RenderOpts,
+    index: usize,
+    rng: &mut SmallRng,
+    sampler: &mut dyn SamplerTrait,
+) -> Srgb<u8> {
     let (x, y, width, height) = index_to_params(opts, index);
-    let mut color: Xyz<E> = Xyz::new(0.0, 0.0, 0.0);
-    for _sample in 0..opts.samples {
-        if let Some(s) = sample(scene, x, y, width, height, rng, opts.max_depth) {
-            color += s
+    let pixel_location = Vec2::new(x, y);
+    let canvas_size = Vec2::new(width, height);
+    let max_depth = opts.max_depth;
+    let mut pixel_color: Xyz<E> = Xyz::new(0.0, 0.0, 0.0);
+    for sample in 0..opts.samples {
+        let Sample {
+            pixel_offset,
+            lens_offset,
+            time,
+            wavelength,
+        } = sampler.sample(x as i32, y as i32, sample as i32);
+        let pixel_uv: Vec2 = Vec2::new(
+            (pixel_location.x + pixel_offset.x) / canvas_size.x,
+            (pixel_location.y + pixel_offset.y) / canvas_size.y,
+        );
+        // note get_ray wants uv 0..1 location
+        let ray: Ray = scene
+            .camera
+            .get_ray(pixel_uv, lens_offset, time, wavelength);
+        let sample_color: Xyz<E> = colorize(&ray, scene, 0, max_depth, rng);
+        if sample_color.x.is_finite() && sample_color.y.is_finite() && sample_color.z.is_finite() {
+            pixel_color += sample_color;
         }
     }
-    color /= opts.samples as Float;
-    let color: Srgb = color.adapt_into();
+    pixel_color /= opts.samples as Float;
+    let color: Srgb = pixel_color.adapt_into();
     let color: Srgb<u8> = color.into_format();
     color
 }
@@ -61,45 +98,19 @@ fn render_pixel_normalmap(
     rng: &mut SmallRng,
 ) -> Srgb<u8> {
     let (x, y, width, height) = index_to_params(opts, index);
-    let color: LinSrgb = sample_normalmap(scene, x, y, width, height, rng);
+    let color: LinSrgb = {
+        let pixel_location = Vec2::new(x / width, y / height);
+        let lens_offset = Vec2::new(0.0, 0.0);
+        let wavelength = random_wavelength(rng);
+        let time = rng.gen();
+        let ray: Ray = scene
+            .camera
+            .get_ray(pixel_location, lens_offset, time, wavelength);
+        normal_map(&ray, scene, rng)
+    };
     let color: Srgb = color.into_color_unclamped();
     let color: Srgb<u8> = color.into_format();
     color
-}
-
-// Get a single sample for a single pixel in the scene, normalmap mode.
-fn sample_normalmap(
-    scene: &Scene,
-    x: Float,
-    y: Float,
-    width: Float,
-    height: Float,
-    rng: &mut SmallRng,
-) -> LinSrgb {
-    let u = x / width;
-    let v = y / height;
-    let ray: Ray = scene.camera.get_ray(u, v, rng);
-    normal_map(&ray, scene, rng)
-}
-
-/// Get a single sample for a single pixel in the scene. Has slight jitter for antialiasing when multisampling.
-fn sample(
-    scene: &Scene,
-    x: Float,
-    y: Float,
-    width: Float,
-    height: Float,
-    rng: &mut SmallRng,
-    max_depth: u32,
-) -> Option<Xyz<E>> {
-    let u = (x + rng.gen::<Float>()) / width;
-    let v = (y + rng.gen::<Float>()) / height;
-    let ray: Ray = scene.camera.get_ray(u, v, rng);
-    let color: Xyz<E> = colorize(&ray, scene, 0, max_depth, rng);
-    if color.x.is_finite() && color.y.is_finite() && color.z.is_finite() {
-        return Some(color);
-    }
-    None
 }
 
 fn index_to_params(opts: &RenderOpts, index: usize) -> (Float, Float, Float, Float) {

--- a/clovers-cli/src/lib.rs
+++ b/clovers-cli/src/lib.rs
@@ -1,2 +1,4 @@
+//! Runtime functions of the `clovers` renderer.
+
 pub mod draw_cpu;
 pub mod sampler;

--- a/clovers-cli/src/lib.rs
+++ b/clovers-cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod draw_cpu;
+pub mod sampler;

--- a/clovers-cli/src/lib.rs
+++ b/clovers-cli/src/lib.rs
@@ -1,4 +1,6 @@
 //! Runtime functions of the `clovers` renderer.
 
+pub mod colorize;
 pub mod draw_cpu;
+pub mod normals;
 pub mod sampler;

--- a/clovers-cli/src/main.rs
+++ b/clovers-cli/src/main.rs
@@ -108,8 +108,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!(); // Empty line before progress bar
     }
 
-    if sampler == Sampler::Blue && !([1, 2, 4, 8, 16, 32, 128, 256].contains(&samples)) {
-        panic!("the blue sampler only supports the following sample-per-pixel counts: [1, 2, 4, 8, 16, 32, 128, 256]");
+    if sampler == Sampler::Blue && !([1, 2, 4, 8, 16, 32, 64, 128, 256].contains(&samples)) {
+        panic!("the blue sampler only supports the following sample-per-pixel counts: [1, 2, 4, 8, 16, 32, 64, 128, 256]");
     }
 
     let renderopts: RenderOpts = RenderOpts {

--- a/clovers-cli/src/main.rs
+++ b/clovers-cli/src/main.rs
@@ -18,9 +18,13 @@ use tracing_subscriber::fmt::time::UtcTime;
 // Internal imports
 use clovers::*;
 #[doc(hidden)]
+mod colorize;
+#[doc(hidden)]
 mod draw_cpu;
 #[doc(hidden)]
 mod json_scene;
+#[doc(hidden)]
+pub mod normals;
 #[doc(hidden)]
 mod sampler;
 use sampler::Sampler;

--- a/clovers-cli/src/main.rs
+++ b/clovers-cli/src/main.rs
@@ -1,6 +1,4 @@
-//! Command Line Interface for the raytracing renderer.
-//!
-//! CPU-based rendering is fully functional. GPU-based rendering is at early experimentation stage only.
+//! Command Line Interface for the `clovers` raytracing renderer.
 
 #![deny(clippy::all)]
 
@@ -19,32 +17,35 @@ use tracing_subscriber::fmt::time::UtcTime;
 
 // Internal imports
 use clovers::*;
+#[doc(hidden)]
 mod draw_cpu;
+#[doc(hidden)]
 mod json_scene;
+#[doc(hidden)]
 mod sampler;
 use sampler::Sampler;
 
-// Configure CLI parameters
+/// Command line parameters for the `clovers` raytracing renderer.
 #[derive(Parser)]
 #[clap(version = "0.1.0", author = "Walther", name = "clovers")]
-struct Opts {
+pub struct Opts {
     /// Input filename / location
     #[clap(short, long)]
     input: String,
-    /// Output filename / location. [default: renders/timestamp.png]
+    /// Output filename / location. Default: renders/unix_timestamp.png
     #[clap(short, long)]
     output: Option<String>,
-    /// Width of the image in pixels
+    /// Width of the image in pixels. Default: 1024
     #[clap(short, long, default_value = "1024")]
     width: u32,
-    /// Height of the image in pixels
+    /// Height of the image in pixels. Default: 1024
     #[clap(short, long, default_value = "1024")]
     height: u32,
-    /// Number of samples to generate per each pixel
-    #[clap(short, long, default_value = "100")]
+    /// Number of samples to generate per each pixel. Default: 64
+    #[clap(short, long, default_value = "64")]
     samples: u32,
-    /// Maximum evaluated bounce depth for each ray
-    #[clap(short = 'd', long, default_value = "100")]
+    /// Maximum evaluated bounce depth for each ray. Default: 64
+    #[clap(short = 'd', long, default_value = "64")]
     max_depth: u32,
     /// Suppress most of the text output
     #[clap(short, long)]
@@ -63,6 +64,7 @@ struct Opts {
     sampler: Sampler,
 }
 
+#[doc(hidden)]
 fn main() -> Result<(), Box<dyn Error>> {
     let Opts {
         input,

--- a/clovers-cli/src/normals.rs
+++ b/clovers-cli/src/normals.rs
@@ -1,6 +1,6 @@
-//! Alternative render method to [colorize](crate::colorize::colorize).
+//! Alternative rendering method. Only returns a normalmap of the image, colorized using standard conventions.
 
-use crate::{
+use clovers::{
     hitable::HitableTrait, ray::Ray, scenes::Scene, Direction, Float, Vec3, EPSILON_SHADOW_ACNE,
 };
 use palette::LinSrgb;

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -43,3 +43,14 @@ impl Display for Sampler {
         write!(f, "{s}")
     }
 }
+
+/// Various sampling dimensions used by the samplers
+#[derive(Clone, Copy)]
+pub enum SamplerDimension {
+    PixelOffsetX,
+    PixelOffsetY,
+    LensOffsetX,
+    LensOffsetY,
+    Time,
+    Wavelength,
+}

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -25,11 +25,11 @@ pub trait SamplerTrait<'scene> {
 
 /// A collection of random values to be used for each sample. Returned as a struct to ensure the correct sampling order for the underlying source of randomness.
 pub struct Randomness {
-    /// Intra-pixel x,y offset. Used for antialiasing.
+    /// Intra-pixel `(x,y)` offset, both in range `[0..1]`. Used for antialiasing.
     pub pixel_offset: Vec2,
-    /// The x,y offset used in the lens equations for aperture / depth-of-field simulation
+    /// The `(x,y)` offset used in the lens equations for aperture / depth-of-field simulation. The coordinates are within the range `[-0.5..0.5]` and within a unit disk.
     pub lens_offset: Vec2,
-    /// The time of the ray, in range 0..1
+    /// The time of the ray, in range `[0..1]`
     pub time: Float,
     /// Wavelength of the ray
     pub wavelength: Wavelength,

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -11,6 +11,15 @@ pub mod random;
 pub trait SamplerTrait<'scene> {
     // TODO: better types
     fn sample(&mut self, i: i32, j: i32, index: i32) -> Sample;
+
+    /// Manually request a sample from the specific dimension
+    fn sample_dimension(
+        &mut self,
+        i: i32,
+        j: i32,
+        index: i32,
+        dimension: SamplerDimension,
+    ) -> Float;
 }
 
 /// A collection of random values to be used for each sample. Returned as a struct to ensure the correct sampling order for the underlying source of randomness.

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -1,3 +1,5 @@
+//! Sampler architecture for the renderer, based on the sampling infrastructure described in the book Physically Based Rendering, chapter [8.3 Sampling Interface](https://pbr-book.org/4ed/Sampling_and_Reconstruction/Sampling_Interface#Sampler)
+
 use std::fmt::Display;
 
 use clap::ValueEnum;
@@ -23,9 +25,12 @@ pub struct Sample {
     pub wavelength: Wavelength,
 }
 
+/// Enum of the supported samplers.
 #[derive(Clone, Debug, PartialEq, ValueEnum)]
 pub enum Sampler {
+    /// Blue noise based sampler, see [BlueSampler](blue::BlueSampler)
     Blue,
+    /// Random number generator based sampler, see [RandomSampler](random::RandomSampler)
     Random,
 }
 

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -10,9 +10,10 @@ pub mod random;
 
 pub trait SamplerTrait<'scene> {
     // TODO: better types
-    fn sample(&mut self, i: i32, j: i32, index: i32) -> Sample;
+    fn sample(&mut self, i: i32, j: i32, index: i32) -> Randomness;
 
     /// Manually request a sample from the specific dimension
+    #[allow(dead_code)] // TODO: remove
     fn sample_dimension(
         &mut self,
         i: i32,
@@ -23,7 +24,7 @@ pub trait SamplerTrait<'scene> {
 }
 
 /// A collection of random values to be used for each sample. Returned as a struct to ensure the correct sampling order for the underlying source of randomness.
-pub struct Sample {
+pub struct Randomness {
     /// Intra-pixel x,y offset. Used for antialiasing.
     pub pixel_offset: Vec2,
     /// The x,y offset used in the lens equations for aperture / depth-of-field simulation

--- a/clovers-cli/src/sampler.rs
+++ b/clovers-cli/src/sampler.rs
@@ -1,0 +1,40 @@
+use std::fmt::Display;
+
+use clap::ValueEnum;
+use clovers::{wavelength::Wavelength, Float, Vec2};
+
+pub mod blue;
+pub mod random;
+
+pub trait SamplerTrait<'scene> {
+    // TODO: better types
+    fn sample(&mut self, i: i32, j: i32, index: i32) -> Sample;
+}
+
+/// A collection of random values to be used for each sample. Returned as a struct to ensure the correct sampling order for the underlying source of randomness.
+pub struct Sample {
+    /// Intra-pixel x,y offset. Used for antialiasing.
+    pub pixel_offset: Vec2,
+    /// The x,y offset used in the lens equations for aperture / depth-of-field simulation
+    pub lens_offset: Vec2,
+    /// The time of the ray, in range 0..1
+    pub time: Float,
+    /// Wavelength of the ray
+    pub wavelength: Wavelength,
+}
+
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
+pub enum Sampler {
+    Blue,
+    Random,
+}
+
+impl Display for Sampler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Sampler::Blue => "blue",
+            Sampler::Random => "random",
+        };
+        write!(f, "{s}")
+    }
+}

--- a/clovers-cli/src/sampler/blue.rs
+++ b/clovers-cli/src/sampler/blue.rs
@@ -2,7 +2,7 @@
 //!
 //! Utilizes library code from <https://github.com/Jasper-Bekkers/blue-noise-sampler>.
 
-use clovers::{wavelength::sample_wavelength, Float, RenderOpts, Vec2};
+use clovers::{wavelength::sample_wavelength, Float, RenderOpts, Vec2, PI};
 
 use super::*;
 
@@ -36,7 +36,7 @@ impl<'scene> SamplerTrait<'scene> for BlueSampler {
             (self.get)(i, j, index, SamplerDimension::PixelOffsetX),
             (self.get)(i, j, index, SamplerDimension::PixelOffsetY),
         );
-        let lens_offset = Vec2::new(
+        let lens_offset = in_unit_disk(
             (self.get)(i, j, index, SamplerDimension::LensOffsetX),
             (self.get)(i, j, index, SamplerDimension::LensOffsetY),
         );
@@ -116,3 +116,15 @@ define_blue_sampler!(spp32);
 define_blue_sampler!(spp64);
 define_blue_sampler!(spp128);
 define_blue_sampler!(spp256);
+
+/// Given two samples in range `[0..1]`, return a sample within `[-0.5 .. 0.5]` unit disk.
+/// Based on <https://stackoverflow.com/a/50746409>
+fn in_unit_disk(x: Float, y: Float) -> Vec2 {
+    // Polar coordinates + correcting for the distribution using sqrt
+    let r = x.sqrt();
+    let theta = y * 2.0 * PI;
+    // Conversion to Cartesian coordinates
+    let x = r * theta.cos();
+    let y = r * theta.sin();
+    Vec2::new(x, y)
+}

--- a/clovers-cli/src/sampler/blue.rs
+++ b/clovers-cli/src/sampler/blue.rs
@@ -31,7 +31,7 @@ impl<'scene> BlueSampler {
 }
 
 impl<'scene> SamplerTrait<'scene> for BlueSampler {
-    fn sample(&mut self, i: i32, j: i32, index: i32) -> Sample {
+    fn sample(&mut self, i: i32, j: i32, index: i32) -> Randomness {
         let pixel_offset = Vec2::new(
             (self.get)(i, j, index, SamplerDimension::PixelOffsetX),
             (self.get)(i, j, index, SamplerDimension::PixelOffsetY),
@@ -44,7 +44,7 @@ impl<'scene> SamplerTrait<'scene> for BlueSampler {
         // TODO: verify uniformity & correctness for math?
         let wavelength = sample_wavelength((self.get)(i, j, index, SamplerDimension::Wavelength));
 
-        Sample {
+        Randomness {
             pixel_offset,
             lens_offset,
             time,

--- a/clovers-cli/src/sampler/blue.rs
+++ b/clovers-cli/src/sampler/blue.rs
@@ -51,6 +51,16 @@ impl<'scene> SamplerTrait<'scene> for BlueSampler {
             wavelength,
         }
     }
+
+    fn sample_dimension(
+        &mut self,
+        i: i32,
+        j: i32,
+        index: i32,
+        dimension: SamplerDimension,
+    ) -> Float {
+        (self.get)(i, j, index, dimension)
+    }
 }
 
 macro_rules! define_blue_sampler {

--- a/clovers-cli/src/sampler/blue.rs
+++ b/clovers-cli/src/sampler/blue.rs
@@ -1,0 +1,96 @@
+use clovers::{wavelength::sample_wavelength, Float, RenderOpts, Vec2};
+
+use super::{Sample, SamplerTrait};
+
+pub struct BlueSampler {
+    get: fn(i32, i32, i32, i32) -> Float,
+}
+
+impl<'scene> BlueSampler {
+    pub fn new(opts: &'scene RenderOpts) -> Self {
+        let get = match opts.samples {
+            1 => blue_sample_spp1,
+            2 => blue_sample_spp2,
+            4 => blue_sample_spp4,
+            8 => blue_sample_spp8,
+            16 => blue_sample_spp16,
+            32 => blue_sample_spp32,
+            64 => blue_sample_spp64,
+            128 => blue_sample_spp128,
+            256 => blue_sample_spp256,
+            _ => unimplemented!(
+                "blue sampler only supports sample-per-pixel counts that are powers of two of and up to 256"
+            ),
+        };
+        Self { get }
+    }
+}
+
+impl<'scene> SamplerTrait<'scene> for BlueSampler {
+    fn sample(&mut self, i: i32, j: i32, index: i32) -> Sample {
+        let pixel_offset = Vec2::new((self.get)(i, j, index, 0), (self.get)(i, j, index, 1));
+        let lens_offset = Vec2::new((self.get)(i, j, index, 2), (self.get)(i, j, index, 3));
+        let time = (self.get)(i, j, index, 4);
+        // TODO: verify uniformity & correctness for math?
+        let wavelength = sample_wavelength((self.get)(i, j, index, 5));
+
+        Sample {
+            pixel_offset,
+            lens_offset,
+            time,
+            wavelength,
+        }
+    }
+}
+
+macro_rules! define_blue_sampler {
+    ($spp:ident) => {
+        ::paste::paste! {
+            pub fn [<blue_sample_ $spp>](
+                mut pixel_i: i32,
+                mut pixel_j: i32,
+                mut sample_index: i32,
+                mut sample_dimension: i32) -> Float {
+                    use blue_noise_sampler::$spp::*;
+
+                    // Adapted from <https://dl.acm.org/doi/10.1145/3306307.3328191> and <https://github.com/Jasper-Bekkers/blue-noise-sampler>
+
+                    // wrap arguments
+                    pixel_i &= 127;
+                    pixel_j &= 127;
+                    sample_index &= 255;
+                    sample_dimension &= 255;
+
+                    // xor index based on optimized ranking
+                    // jb: 1spp blue noise has all 0 in g_blueNoiseRankingTile so we can skip the load
+                    let index = sample_dimension + (pixel_i + pixel_j * 128) * 8;
+                    let index = index as usize;
+                    let ranked_sample_index = sample_index ^ RANKING_TILE[index];
+
+                    // fetch value in sequence
+                    let index = sample_dimension + ranked_sample_index * 256;
+                    let index = index as usize;
+                    let value = SOBOL[index];
+
+                    // If the dimension is optimized, xor sequence value based on optimized scrambling
+                    let index = (sample_dimension % 8) + (pixel_i + pixel_j * 128) * 8;
+                    let index = index as usize;
+                    let value = value ^ SCRAMBLING_TILE[index];
+
+                    // convert to float and return
+                    let v: Float = (0.5 + value as Float) / 256.0;
+                    v
+            }
+        }
+    };
+}
+
+define_blue_sampler!(spp1);
+define_blue_sampler!(spp2);
+define_blue_sampler!(spp4);
+define_blue_sampler!(spp8);
+define_blue_sampler!(spp16);
+define_blue_sampler!(spp32);
+define_blue_sampler!(spp64);
+define_blue_sampler!(spp128);
+define_blue_sampler!(spp256);

--- a/clovers-cli/src/sampler/blue.rs
+++ b/clovers-cli/src/sampler/blue.rs
@@ -1,3 +1,7 @@
+//! A sampler based on blue noise. Works especially well at low samples-per-pixel counts.
+//!
+//! Utilizes library code from <https://github.com/Jasper-Bekkers/blue-noise-sampler>
+
 use clovers::{wavelength::sample_wavelength, Float, RenderOpts, Vec2};
 
 use super::{Sample, SamplerTrait};

--- a/clovers-cli/src/sampler/random.rs
+++ b/clovers-cli/src/sampler/random.rs
@@ -1,0 +1,31 @@
+use clovers::{random::random_in_unit_disk, wavelength::random_wavelength, Vec2};
+use rand::{rngs::SmallRng, Rng};
+
+use super::{Sample, SamplerTrait};
+
+#[derive(Debug)]
+pub struct RandomSampler<'scene> {
+    rng: &'scene mut SmallRng,
+}
+
+impl<'scene> RandomSampler<'scene> {
+    pub fn new(rng: &'scene mut SmallRng) -> Self {
+        Self { rng }
+    }
+}
+
+impl<'scene> SamplerTrait<'scene> for RandomSampler<'scene> {
+    fn sample(&mut self, _i: i32, _j: i32, _index: i32) -> Sample {
+        let pixel_offset = Vec2::new(self.rng.gen(), self.rng.gen());
+        let lens_offset = random_in_unit_disk(self.rng).xy();
+        let time = self.rng.gen();
+        let wavelength = random_wavelength(self.rng);
+
+        Sample {
+            pixel_offset,
+            lens_offset,
+            time,
+            wavelength,
+        }
+    }
+}

--- a/clovers-cli/src/sampler/random.rs
+++ b/clovers-cli/src/sampler/random.rs
@@ -3,7 +3,7 @@
 use clovers::{random::random_in_unit_disk, wavelength::random_wavelength, Vec2};
 use rand::{rngs::SmallRng, Rng};
 
-use super::{Sample, SamplerTrait};
+use super::{Randomness, SamplerTrait};
 
 #[derive(Debug)]
 pub struct RandomSampler<'scene> {
@@ -17,13 +17,13 @@ impl<'scene> RandomSampler<'scene> {
 }
 
 impl<'scene> SamplerTrait<'scene> for RandomSampler<'scene> {
-    fn sample(&mut self, _i: i32, _j: i32, _index: i32) -> Sample {
+    fn sample(&mut self, _i: i32, _j: i32, _index: i32) -> Randomness {
         let pixel_offset = Vec2::new(self.rng.gen(), self.rng.gen());
         let lens_offset = random_in_unit_disk(self.rng).xy();
         let time = self.rng.gen();
         let wavelength = random_wavelength(self.rng);
 
-        Sample {
+        Randomness {
             pixel_offset,
             lens_offset,
             time,

--- a/clovers-cli/src/sampler/random.rs
+++ b/clovers-cli/src/sampler/random.rs
@@ -1,3 +1,5 @@
+//! A sampler based on a random number generator. This is the default sampler used in this renderer. It works especially well at high samples-per-pixel counts.
+
 use clovers::{random::random_in_unit_disk, wavelength::random_wavelength, Vec2};
 use rand::{rngs::SmallRng, Rng};
 

--- a/clovers-cli/src/sampler/random.rs
+++ b/clovers-cli/src/sampler/random.rs
@@ -30,4 +30,14 @@ impl<'scene> SamplerTrait<'scene> for RandomSampler<'scene> {
             wavelength,
         }
     }
+
+    fn sample_dimension(
+        &mut self,
+        _i: i32,
+        _j: i32,
+        _index: i32,
+        _dimension: super::SamplerDimension,
+    ) -> clovers::Float {
+        self.rng.gen()
+    }
 }

--- a/clovers-cli/src/sampler/random.rs
+++ b/clovers-cli/src/sampler/random.rs
@@ -19,7 +19,7 @@ impl<'scene> RandomSampler<'scene> {
 impl<'scene> SamplerTrait<'scene> for RandomSampler<'scene> {
     fn sample(&mut self, _i: i32, _j: i32, _index: i32) -> Randomness {
         let pixel_offset = Vec2::new(self.rng.gen(), self.rng.gen());
-        let lens_offset = random_in_unit_disk(self.rng).xy();
+        let lens_offset = random_in_unit_disk(self.rng);
         let time = self.rng.gen();
         let wavelength = random_wavelength(self.rng);
 

--- a/clovers/README.md
+++ b/clovers/README.md
@@ -1,3 +1,3 @@
 # clovers 🍀 ray tracing in rust 🦀
 
-This directory contains the main `clovers` library and CLI binary.
+This directory contains the main `clovers` library.

--- a/clovers/src/bvhnode.rs
+++ b/clovers/src/bvhnode.rs
@@ -17,9 +17,9 @@ use crate::{
 /// A node in a tree structure defining a hierarchy of objects in a scene: a node knows its bounding box, and has two children which are also `BVHNode`s. This is used for accelerating the ray-object intersection calculation in the ray tracer. See [Bounding Volume hierarchies](https://raytracing.github.io/books/RayTracingTheNextWeek.html)
 #[derive(Debug, Clone)]
 pub struct BVHNode<'scene> {
-    /// Left child of the BVHNode
+    /// Left child of the `BVHNode`
     pub left: Box<Hitable<'scene>>,
-    /// Right child of the BVHNode
+    /// Right child of the `BVHNode`
     pub right: Box<Hitable<'scene>>,
     /// Bounding box containing both of the child nodes
     pub bounding_box: AABB,

--- a/clovers/src/lib.rs
+++ b/clovers/src/lib.rs
@@ -37,7 +37,6 @@
 //!
 //! You most likely want to repeat this process multiple times for each of your pixels: generating multiple samples per pixel results in a higher quality image.
 //!
-//! The library provides an opinionated [`colorize()`](colorize::colorize) function that does the steps mentioned above. Using it is optional - feel free to implement your own methods that utilize the lower-level building blocks for more creative power!
 //!
 //! ## Post processing
 //!
@@ -81,11 +80,9 @@ pub mod aabb;
 pub mod bvhnode;
 pub mod camera;
 pub mod colorinit;
-pub mod colorize;
 pub mod hitable;
 pub mod interval;
 pub mod materials;
-pub mod normals;
 pub mod objects;
 pub mod onb;
 pub mod pdf;

--- a/clovers/src/materials.rs
+++ b/clovers/src/materials.rs
@@ -132,7 +132,7 @@ pub struct ScatterRecord<'ray> {
     pub specular_ray: Option<Ray>,
     /// Current color to take into account when following the scattered ray for futher iterations
     pub attenuation: Xyz<E>,
-    /// Probability density function to use with the [ScatterRecord].
+    /// Probability density function to use with the [`ScatterRecord`].
     // TODO: understand & explain
     pub pdf_ptr: PDF<'ray>,
 }

--- a/clovers/src/objects.rs
+++ b/clovers/src/objects.rs
@@ -56,15 +56,15 @@ pub struct ObjectList {
 pub enum Object {
     /// Boxy object initializer
     Boxy(BoxyInit),
-    /// ConstantMedium object initializer
+    /// `ConstantMedium` object initializer
     ConstantMedium(ConstantMediumInit),
-    /// MovingSphere object initializer
+    /// `MovingSphere` object initializer
     MovingSphere(MovingSphereInit),
-    /// ObjectList object initializer
+    /// `ObjectList` object initializer
     ObjectList(ObjectList),
     /// Quad object initializer
     Quad(QuadInit),
-    /// RotateY object initializer
+    /// `RotateY` object initializer
     RotateY(RotateInit),
     /// Sphere object initializer
     Sphere(SphereInit),

--- a/clovers/src/objects/constant_medium.rs
+++ b/clovers/src/objects/constant_medium.rs
@@ -72,21 +72,16 @@ impl<'scene> HitableTrait for ConstantMedium<'scene> {
     ) -> Option<HitRecord> {
         // TODO: explain how the fog works.
 
-        let Some(mut rec1) = self
+        let mut rec1 = self
             .boundary
-            .hit(ray, Float::NEG_INFINITY, Float::INFINITY, rng)
-        else {
-            return None;
-        };
+            .hit(ray, Float::NEG_INFINITY, Float::INFINITY, rng)?;
 
-        let Some(mut rec2) = self.boundary.hit(
+        let mut rec2 = self.boundary.hit(
             ray,
             rec1.distance + EPSILON_CONSTANT_MEDIUM,
             Float::INFINITY,
             rng,
-        ) else {
-            return None;
-        };
+        )?;
 
         if rec1.distance < distance_min {
             rec1.distance = distance_min;

--- a/clovers/src/objects/gltf.rs
+++ b/clovers/src/objects/gltf.rs
@@ -178,9 +178,9 @@ fn parse_mesh<'scene>(
                         .into_f32()
                         .collect();
                     let all_normals: Option<Vec<_>> =
-                        reader.read_normals().map(core::iter::Iterator::collect);
+                        reader.read_normals().map(Iterator::collect);
                     let all_tangents: Option<Vec<_>> =
-                        reader.read_tangents().map(core::iter::Iterator::collect);
+                        reader.read_tangents().map(Iterator::collect);
 
                     while i < len {
                         let triangle = [

--- a/clovers/src/objects/gltf.rs
+++ b/clovers/src/objects/gltf.rs
@@ -177,8 +177,7 @@ fn parse_mesh<'scene>(
                         .unwrap()
                         .into_f32()
                         .collect();
-                    let all_normals: Option<Vec<_>> =
-                        reader.read_normals().map(Iterator::collect);
+                    let all_normals: Option<Vec<_>> = reader.read_normals().map(Iterator::collect);
                     let all_tangents: Option<Vec<_>> =
                         reader.read_tangents().map(Iterator::collect);
 

--- a/clovers/src/objects/moving_sphere.rs
+++ b/clovers/src/objects/moving_sphere.rs
@@ -19,9 +19,9 @@ pub struct MovingSphereInit {
     /// Used for multiple importance sampling
     #[cfg_attr(feature = "serde-derive", serde(default))]
     pub priority: bool,
-    /// Center point of the sphere at time_0
+    /// Center point of the sphere at `time_0`
     pub center_0: Position,
-    /// Center point of the sphere at time_1
+    /// Center point of the sphere at `time_1`
     pub center_1: Position,
     /// Radius of the sphere.
     pub radius: Float,
@@ -33,9 +33,9 @@ pub struct MovingSphereInit {
 #[derive(Debug, Clone)]
 /// A moving sphere object. This is represented by one `radius`, two center points `center_0` `center_1`, two times `time_0` `time_1`, and a [Material]. Any [Rays](Ray) hitting the object will also have an internal `time` value, which will be used for determining the interpolated position of the sphere at that time. With lots of rays hitting every pixel but at randomized times, we get temporal multiplexing and an approximation of perceived motion blur.
 pub struct MovingSphere<'scene> {
-    /// Center point of the sphere at time_0
+    /// Center point of the sphere at `time_0`
     pub center_0: Position,
-    /// Center point of the sphere at time_1
+    /// Center point of the sphere at `time_1`
     pub center_1: Position,
     /// Time 0
     pub time_0: Float,

--- a/clovers/src/pdf.rs
+++ b/clovers/src/pdf.rs
@@ -24,7 +24,7 @@ pub enum PDF<'scene> {
 }
 
 #[enum_dispatch]
-pub(crate) trait PDFTrait {
+pub trait PDFTrait {
     #[must_use]
     fn value(
         &self,

--- a/clovers/src/random.rs
+++ b/clovers/src/random.rs
@@ -1,6 +1,6 @@
 //! Various internal helper functions for getting specific kinds of random values.
 
-use crate::{Direction, Float, Vec3, PI};
+use crate::{Direction, Float, Vec2, Vec3, PI};
 use nalgebra::Unit;
 use rand::rngs::SmallRng;
 use rand::Rng;
@@ -15,9 +15,9 @@ pub fn random_unit_vector(rng: &mut SmallRng) -> Direction {
 
 /// Internal helper.
 #[must_use]
-pub fn random_in_unit_disk(rng: &mut SmallRng) -> Vec3 {
+pub fn random_in_unit_disk(rng: &mut SmallRng) -> Vec2 {
     let v: [Float; 2] = UnitDisc.sample(rng);
-    Vec3::new(v[0], v[1], 0.0)
+    Vec2::new(v[0], v[1])
 }
 
 /// Internal helper.

--- a/clovers/src/scenes.rs
+++ b/clovers/src/scenes.rs
@@ -18,13 +18,13 @@ use tracing::info;
 #[derive(Debug)]
 /// A representation of the scene that is being rendered.
 pub struct Scene<'scene> {
-    /// Bounding-volume hierarchy of [Hitable] objects in the scene. This could, as currently written, be any [Hitable] - in practice, we place the root of the [BVHNode] tree here.
+    /// Bounding-volume hierarchy of [Hitable] objects in the scene. This could, as currently written, be any [Hitable] - in practice, we place the root of the [`BVHNode`] tree here.
     pub hitables: BVHNode<'scene>,
     /// The camera object used for rendering the scene.
     pub camera: Camera,
     /// The background color to use when the rays do not hit anything in the scene.
     pub background_color: Srgb, // TODO: make into Texture or something?
-    /// A [BVHNode] tree of prioritized objects - e.g. glass items or lights - that affect the biased sampling of the scene. Wrapped into a [Hitable] for convenience reasons (see various PDF functions).
+    /// A [`BVHNode`] tree of prioritized objects - e.g. glass items or lights - that affect the biased sampling of the scene. Wrapped into a [Hitable] for convenience reasons (see various PDF functions).
     pub priority_hitables: Hitable<'scene>,
 }
 

--- a/clovers/src/wavelength.rs
+++ b/clovers/src/wavelength.rs
@@ -29,6 +29,19 @@ pub fn random_wavelength(rng: &mut SmallRng) -> Wavelength {
     SPECTRUM.sample_single(rng)
 }
 
+// TODO: clippy fixes possible?
+/// Given a sample seed from a sampler, return the approximate wavelenght.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_precision_loss)]
+pub fn sample_wavelength(sample: Float) -> Wavelength {
+    let pick = (sample * SPECTRUM_SIZE as Float).floor() as usize + MIN_WAVELENGTH;
+    assert!(pick <= MAX_WAVELENGTH);
+    assert!(pick >= MIN_WAVELENGTH);
+    pick
+}
+
 /// Given a hero wavelength, create additional equidistant wavelengths in the visible spectrum. Returns an array of wavelengths, with the original hero wavelength as the first one.
 #[must_use]
 pub fn rotate_wavelength(hero: Wavelength) -> [Wavelength; WAVE_SAMPLE_COUNT] {


### PR DESCRIPTION
Initial implementation of Blue Noise Sampling, as described in <https://dl.acm.org/doi/10.1145/3306307.3328191>.

Fixes #166 

Note: this is not a 100% full implementation yet - even when using the `--sampler blue`, _some_ decisions are made based on a `rng.gen()` random sampler. Fully deterministic use of the sampler should be completed in later PRs.

---

Check the full-resolution images at 100% zoom level. Left: random sampling. Right: blue noise sampling.

colorchecker, 1spp
![colorchecker-1](https://github.com/Walther/clovers/assets/2943750/986f659e-314a-4070-a79b-2e6fb4f19c70)

colorchecker, 16spp
![colorchecker-16](https://github.com/Walther/clovers/assets/2943750/fd26cb84-262f-4d7f-8eeb-d4b7b1344b51)

cornell, 1spp
![cornell-1](https://github.com/Walther/clovers/assets/2943750/41da1b85-6131-49d3-9d5c-ae67b1b63381)

cornell, 16spp
![cornell-16](https://github.com/Walther/clovers/assets/2943750/4e1643de-12bd-4b1a-8616-48a452d05940)
